### PR TITLE
Change nexus schema url

### DIFF
--- a/docs/ontology/Action.md
+++ b/docs/ontology/Action.md
@@ -9,7 +9,7 @@ _Action to remediate a risk_
 
 
 
-URI: [nexus:Action](http://research.ibm.com/ontologies/aiont/Action)
+URI: [nexus:Action](https://ibm.github.io/risk-atlas-nexus/ontology/Action)
 
 
 
@@ -119,7 +119,7 @@ URI: [nexus:Action](http://research.ibm.com/ontologies/aiont/Action)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -147,7 +147,7 @@ URI: [nexus:Action](http://research.ibm.com/ontologies/aiont/Action)
 ```yaml
 name: Action
 description: Action to remediate a risk
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - hasRelatedRisk
@@ -164,13 +164,13 @@ slots:
 ```yaml
 name: Action
 description: Action to remediate a risk
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   hasRelatedRisk:
     name: hasRelatedRisk
     description: A relationship where an entity relates to a risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasRelatedRisk
     owner: Action
@@ -183,7 +183,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -202,7 +202,7 @@ attributes:
     name: isDefinedByTaxonomy
     description: A relationship where a risk or a risk group is defined by a risk
       taxonomy
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isDefinedByTaxonomy
@@ -218,7 +218,7 @@ attributes:
     description: Pertinent AI Actor Tasks for each subcategory. Not every AI Actor
       Task listed will apply to every suggested action in the subcategory (i.e., some
       apply to AI development and others apply to AI deployment).
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasAiActorTask
     owner: Action
@@ -230,7 +230,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -243,7 +243,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -254,7 +254,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -265,7 +265,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -276,7 +276,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -288,7 +288,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiAgent.md
+++ b/docs/ontology/AiAgent.md
@@ -9,7 +9,7 @@ _An artificial intelligence (AI) agent refers to a system or program that is cap
 
 
 
-URI: [nexus:AiAgent](http://research.ibm.com/ontologies/aiont/AiAgent)
+URI: [nexus:AiAgent](https://ibm.github.io/risk-atlas-nexus/ontology/AiAgent)
 
 
 
@@ -153,7 +153,7 @@ URI: [nexus:AiAgent](http://research.ibm.com/ontologies/aiont/AiAgent)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -183,7 +183,7 @@ name: AiAgent
 description: An artificial intelligence (AI) agent refers to a system or program that
   is capable of autonomously performing tasks on behalf of a user or another system
   by designing its workflow and utilizing available tools.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiSystem
 slot_usage:
   isProvidedBy:
@@ -202,7 +202,7 @@ name: AiAgent
 description: An artificial intelligence (AI) agent refers to a system or program that
   is capable of autonomously performing tasks on behalf of a user or another system
   by designing its workflow and utilizing available tools.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiSystem
 slot_usage:
   isProvidedBy:
@@ -213,7 +213,7 @@ attributes:
   hasEuAiSystemType:
     name: hasEuAiSystemType
     description: The type of system as defined by the EU AI Act.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasEuAiSystemType
     owner: AiAgent
@@ -223,7 +223,7 @@ attributes:
   hasEuRiskCategory:
     name: hasEuRiskCategory
     description: The risk category of an AI system as defined by the EU AI Act.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasEuRiskCategory
     owner: AiAgent
@@ -233,7 +233,7 @@ attributes:
   producer:
     name: producer
     description: A relationship to the Organization instance which produces this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: producer
     owner: AiAgent
@@ -243,7 +243,7 @@ attributes:
   hasModelCard:
     name: hasModelCard
     description: A relationship to model card references.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasModelCard
     owner: AiAgent
@@ -256,7 +256,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -274,7 +274,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -288,7 +288,7 @@ attributes:
   performsTask:
     name: performsTask
     description: relationship indicating the AI tasks an AI model can perform.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: performsTask
     owner: AiAgent
@@ -301,7 +301,7 @@ attributes:
     name: isProvidedBy
     description: A relationship indicating the AI agent has been provided by an AI
       systems provider.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:isProvidedBy
     alias: isProvidedBy
@@ -313,7 +313,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -326,7 +326,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -337,7 +337,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -348,7 +348,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -359,7 +359,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -371,7 +371,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiEval.md
+++ b/docs/ontology/AiEval.md
@@ -141,7 +141,7 @@ URI: [dqv:Metric](https://www.w3.org/TR/vocab-dqv/Metric)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -170,7 +170,7 @@ URI: [dqv:Metric](https://www.w3.org/TR/vocab-dqv/Metric)
 name: AiEval
 description: An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a
   question or a combination of such entities.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - hasDocumentation
@@ -197,7 +197,7 @@ class_uri: dqv:Metric
 name: AiEval
 description: An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a
   question or a combination of such entities.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slot_usage:
   isComposedOf:
@@ -209,7 +209,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -227,7 +227,7 @@ attributes:
   hasDataset:
     name: hasDataset
     description: A relationship to datasets that are used.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasDataset
     owner: AiEval
@@ -239,7 +239,7 @@ attributes:
   hasUnitxtCard:
     name: hasUnitxtCard
     description: A relationship to a Unitxt card defining the risk evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: hasUnitxtCard
@@ -250,7 +250,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -264,7 +264,7 @@ attributes:
   hasRelatedRisk:
     name: hasRelatedRisk
     description: A relationship where an entity relates to a risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasRelatedRisk
     owner: AiEval
@@ -277,7 +277,7 @@ attributes:
   bestValue:
     name: bestValue
     description: Annotation of the best possible result of the evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: bestValue
     owner: AiEval
@@ -288,7 +288,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -301,7 +301,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -312,7 +312,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -323,7 +323,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -334,7 +334,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -346,7 +346,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiEvalResult.md
+++ b/docs/ontology/AiEvalResult.md
@@ -104,7 +104,7 @@ URI: [dqv:QualityMeasurement](https://www.w3.org/TR/vocab-dqv/QualityMeasurement
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -132,7 +132,7 @@ URI: [dqv:QualityMeasurement](https://www.w3.org/TR/vocab-dqv/QualityMeasurement
 ```yaml
 name: AiEvalResult
 description: The result of an evaluation for a specific AI model.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - Fact
@@ -149,7 +149,7 @@ class_uri: dqv:QualityMeasurement
 ```yaml
 name: AiEvalResult
 description: The result of an evaluation for a specific AI model.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - Fact
@@ -157,7 +157,7 @@ attributes:
   isResultOf:
     name: isResultOf
     description: A relationship indicating that an entity is the result of an AI evaluation.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: dqv:isMeasurementOf
     alias: isResultOf
@@ -169,7 +169,7 @@ attributes:
   value:
     name: value
     description: Some numeric or string value
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: value
     owner: AiEvalResult
@@ -181,7 +181,7 @@ attributes:
     name: evidence
     description: Evidence provides a source (typical a chunk, paragraph or link) describing
       where some value was found or how it was generated.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: evidence
     owner: AiEvalResult
@@ -192,7 +192,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -205,7 +205,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -216,7 +216,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -227,7 +227,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -238,7 +238,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -250,7 +250,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiLifecyclePhase.md
+++ b/docs/ontology/AiLifecyclePhase.md
@@ -89,7 +89,7 @@ URI: [airo:AILifecyclePhase](https://w3id.org/airo#AILifecyclePhase)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -118,7 +118,7 @@ URI: [airo:AILifecyclePhase](https://w3id.org/airo#AILifecyclePhase)
 name: AiLifecyclePhase
 description: A Phase of AI lifecycle which indicates evolution of the system from
   conception through retirement.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 abstract: true
 class_uri: airo:AILifecyclePhase
@@ -133,7 +133,7 @@ class_uri: airo:AILifecyclePhase
 name: AiLifecyclePhase
 description: A Phase of AI lifecycle which indicates evolution of the system from
   conception through retirement.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 abstract: true
 attributes:
@@ -141,7 +141,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -154,7 +154,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -165,7 +165,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -176,7 +176,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -187,7 +187,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -199,7 +199,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiModel.md
+++ b/docs/ontology/AiModel.md
@@ -9,7 +9,7 @@ _A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclasse
 
 
 
-URI: [nexus:AiModel](http://research.ibm.com/ontologies/aiont/AiModel)
+URI: [nexus:AiModel](https://ibm.github.io/risk-atlas-nexus/ontology/AiModel)
 
 
 
@@ -170,7 +170,7 @@ URI: [nexus:AiModel](http://research.ibm.com/ontologies/aiont/AiModel)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -199,7 +199,7 @@ URI: [nexus:AiModel](http://research.ibm.com/ontologies/aiont/AiModel)
 name: AiModel
 description: A base AI Model class. No assumption about the type (SVM, LLM, etc.).
   Subclassed by model types (see LargeLanguageModel).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: BaseAi
 slots:
 - hasEvaluation
@@ -219,13 +219,13 @@ slots:
 name: AiModel
 description: A base AI Model class. No assumption about the type (SVM, LLM, etc.).
   Subclassed by model types (see LargeLanguageModel).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: BaseAi
 attributes:
   hasEvaluation:
     name: hasEvaluation
     description: A relationship indicating that an entity has an AI evaluation result.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: dqv:hasQualityMeasurement
     alias: hasEvaluation
@@ -239,7 +239,7 @@ attributes:
   architecture:
     name: architecture
     description: A description of the architecture of an AI such as 'Decoder-only'.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: architecture
     owner: AiModel
@@ -249,7 +249,7 @@ attributes:
   gpu_hours:
     name: gpu_hours
     description: GPU consumption in terms of hours
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: gpu_hours
     owner: AiModel
@@ -260,7 +260,7 @@ attributes:
   power_consumption_w:
     name: power_consumption_w
     description: power consumption in Watts
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: power_consumption_w
     owner: AiModel
@@ -272,7 +272,7 @@ attributes:
     name: carbon_emitted
     description: The number of tons of carbon dioxide equivalent that are emitted
       during training
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: carbon_emitted
     owner: AiModel
@@ -287,7 +287,7 @@ attributes:
     name: hasRiskControl
     description: Indicates the control measures associated with a system or component
       to modify risks.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasRiskControl
     alias: hasRiskControl
@@ -299,7 +299,7 @@ attributes:
   producer:
     name: producer
     description: A relationship to the Organization instance which produces this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: producer
     owner: AiModel
@@ -309,7 +309,7 @@ attributes:
   hasModelCard:
     name: hasModelCard
     description: A relationship to model card references.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasModelCard
     owner: AiModel
@@ -322,7 +322,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -340,7 +340,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -354,7 +354,7 @@ attributes:
   performsTask:
     name: performsTask
     description: relationship indicating the AI tasks an AI model can perform.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: performsTask
     owner: AiModel
@@ -367,7 +367,7 @@ attributes:
     name: isProvidedBy
     description: A relationship indicating the AI model has been provided by an AI
       model provider.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:isProvidedBy
     alias: isProvidedBy
@@ -379,7 +379,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -392,7 +392,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -403,7 +403,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -414,7 +414,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -425,7 +425,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -437,7 +437,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiModelValidation.md
+++ b/docs/ontology/AiModelValidation.md
@@ -9,7 +9,7 @@ _AI model validation steps that have been performed after the model training to 
 
 
 
-URI: [nexus:AiModelValidation](http://research.ibm.com/ontologies/aiont/AiModelValidation)
+URI: [nexus:AiModelValidation](https://ibm.github.io/risk-atlas-nexus/ontology/AiModelValidation)
 
 
 
@@ -79,7 +79,7 @@ URI: [nexus:AiModelValidation](http://research.ibm.com/ontologies/aiont/AiModelV
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -108,7 +108,7 @@ URI: [nexus:AiModelValidation](http://research.ibm.com/ontologies/aiont/AiModelV
 name: AiModelValidation
 description: AI model validation steps that have been performed after the model training
   to ensure high AI model quality.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiLifecyclePhase
 
 ```
@@ -121,14 +121,14 @@ is_a: AiLifecyclePhase
 name: AiModelValidation
 description: AI model validation steps that have been performed after the model training
   to ensure high AI model quality.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiLifecyclePhase
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -141,7 +141,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -152,7 +152,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -163,7 +163,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -174,7 +174,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -186,7 +186,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiOffice.md
+++ b/docs/ontology/AiOffice.md
@@ -89,7 +89,7 @@ URI: [schema:Organization](http://schema.org/Organization)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -117,7 +117,7 @@ URI: [schema:Organization](http://schema.org/Organization)
 ```yaml
 name: AiOffice
 description: The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office)
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Organization
 class_uri: schema:Organization
 
@@ -130,14 +130,14 @@ class_uri: schema:Organization
 ```yaml
 name: AiOffice
 description: The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office)
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Organization
 attributes:
   grants_license:
     name: grants_license
     description: A relationship from a granting entity such as an Organization to
       a License instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: grants_license
     owner: AiOffice
@@ -148,7 +148,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -161,7 +161,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -172,7 +172,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -183,7 +183,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -194,7 +194,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -206,7 +206,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiProvider.md
+++ b/docs/ontology/AiProvider.md
@@ -100,7 +100,7 @@ URI: [airo:AIProvider](https://w3id.org/airo#AIProvider)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -132,7 +132,7 @@ description: A provider under the AI Act is defined by Article 3(3) as a natural
   an AI system or general-purpose AI model developed; and places that system or model
   on the market, or puts that system into service, under the provider's own name or
   trademark, whether for payment or free for charge.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Organization
 class_uri: airo:AIProvider
 
@@ -149,14 +149,14 @@ description: A provider under the AI Act is defined by Article 3(3) as a natural
   an AI system or general-purpose AI model developed; and places that system or model
   on the market, or puts that system into service, under the provider's own name or
   trademark, whether for payment or free for charge.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Organization
 attributes:
   grants_license:
     name: grants_license
     description: A relationship from a granting entity such as an Organization to
       a License instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: grants_license
     owner: AiProvider
@@ -167,7 +167,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -180,7 +180,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -191,7 +191,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -202,7 +202,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -213,7 +213,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -225,7 +225,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiSystem.md
+++ b/docs/ontology/AiSystem.md
@@ -158,7 +158,7 @@ URI: [airo:AISystem](https://w3id.org/airo#AISystem)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -187,7 +187,7 @@ URI: [airo:AISystem](https://w3id.org/airo#AISystem)
 name: AiSystem
 description: A compound AI System composed of one or more AI capablities. ChatGPT
   is an example of an AI system which deploys multiple GPT AI models.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: BaseAi
 slots:
 - hasEuAiSystemType
@@ -210,7 +210,7 @@ class_uri: airo:AISystem
 name: AiSystem
 description: A compound AI System composed of one or more AI capablities. ChatGPT
   is an example of an AI system which deploys multiple GPT AI models.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: BaseAi
 slot_usage:
   isComposedOf:
@@ -222,7 +222,7 @@ attributes:
   hasEuAiSystemType:
     name: hasEuAiSystemType
     description: The type of system as defined by the EU AI Act.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasEuAiSystemType
     owner: AiSystem
@@ -232,7 +232,7 @@ attributes:
   hasEuRiskCategory:
     name: hasEuRiskCategory
     description: The risk category of an AI system as defined by the EU AI Act.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasEuRiskCategory
     owner: AiSystem
@@ -242,7 +242,7 @@ attributes:
   producer:
     name: producer
     description: A relationship to the Organization instance which produces this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: producer
     owner: AiSystem
@@ -252,7 +252,7 @@ attributes:
   hasModelCard:
     name: hasModelCard
     description: A relationship to model card references.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasModelCard
     owner: AiSystem
@@ -265,7 +265,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -283,7 +283,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -297,7 +297,7 @@ attributes:
   performsTask:
     name: performsTask
     description: relationship indicating the AI tasks an AI model can perform.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: performsTask
     owner: AiSystem
@@ -310,7 +310,7 @@ attributes:
     name: isProvidedBy
     description: A relationship indicating the AI model has been provided by an AI
       model provider.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:isProvidedBy
     alias: isProvidedBy
@@ -322,7 +322,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -335,7 +335,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -346,7 +346,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -357,7 +357,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -368,7 +368,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -380,7 +380,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/AiSystemType.md
+++ b/docs/ontology/AiSystemType.md
@@ -40,7 +40,7 @@ URI: [AiSystemType](AiSystemType.md)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -52,7 +52,7 @@ URI: [AiSystemType](AiSystemType.md)
 <details>
 ```yaml
 name: AiSystemType
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 permissible_values:
   GPAI:

--- a/docs/ontology/AiTask.md
+++ b/docs/ontology/AiTask.md
@@ -90,7 +90,7 @@ URI: [airo:AiCapability](https://w3id.org/airo#AiCapability)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -118,7 +118,7 @@ URI: [airo:AiCapability](https://w3id.org/airo#AiCapability)
 ```yaml
 name: AiTask
 description: A task, such as summarization and classification, performed by an AI.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 class_uri: airo:AiCapability
 
@@ -131,14 +131,14 @@ class_uri: airo:AiCapability
 ```yaml
 name: AiTask
 description: A task, such as summarization and classification, performed by an AI.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -151,7 +151,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -162,7 +162,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -173,7 +173,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -184,7 +184,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -196,7 +196,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Any.md
+++ b/docs/ontology/Any.md
@@ -64,7 +64,7 @@ URI: [linkml:Any](https://w3id.org/linkml/Any)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -91,7 +91,7 @@ URI: [linkml:Any](https://w3id.org/linkml/Any)
 <details>
 ```yaml
 name: Any
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 class_uri: linkml:Any
 
 ```
@@ -102,7 +102,7 @@ class_uri: linkml:Any
 <details>
 ```yaml
 name: Any
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 class_uri: linkml:Any
 
 ```

--- a/docs/ontology/BaseAi.md
+++ b/docs/ontology/BaseAi.md
@@ -11,7 +11,7 @@ _Any type of AI, be it a LLM, RL agent, SVM, etc._
 * __NOTE__: this is an abstract class and should not be instantiated directly
 
 
-URI: [nexus:BaseAi](http://research.ibm.com/ontologies/aiont/BaseAi)
+URI: [nexus:BaseAi](https://ibm.github.io/risk-atlas-nexus/ontology/BaseAi)
 
 
 
@@ -142,7 +142,7 @@ URI: [nexus:BaseAi](http://research.ibm.com/ontologies/aiont/BaseAi)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -170,7 +170,7 @@ URI: [nexus:BaseAi](http://research.ibm.com/ontologies/aiont/BaseAi)
 ```yaml
 name: BaseAi
 description: Any type of AI, be it a LLM, RL agent, SVM, etc.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 abstract: true
 slots:
@@ -190,14 +190,14 @@ slots:
 ```yaml
 name: BaseAi
 description: Any type of AI, be it a LLM, RL agent, SVM, etc.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 abstract: true
 attributes:
   producer:
     name: producer
     description: A relationship to the Organization instance which produces this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: producer
     owner: BaseAi
@@ -207,7 +207,7 @@ attributes:
   hasModelCard:
     name: hasModelCard
     description: A relationship to model card references.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasModelCard
     owner: BaseAi
@@ -220,7 +220,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -238,7 +238,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -252,7 +252,7 @@ attributes:
   performsTask:
     name: performsTask
     description: relationship indicating the AI tasks an AI model can perform.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: performsTask
     owner: BaseAi
@@ -265,7 +265,7 @@ attributes:
     name: isProvidedBy
     description: A relationship indicating the AI model has been provided by an AI
       model provider.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:isProvidedBy
     alias: isProvidedBy
@@ -277,7 +277,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -290,7 +290,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -301,7 +301,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -312,7 +312,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -323,7 +323,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -335,7 +335,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Boolean.md
+++ b/docs/ontology/Boolean.md
@@ -33,7 +33,7 @@ URI: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Container.md
+++ b/docs/ontology/Container.md
@@ -9,7 +9,7 @@ _An umbrella object that holds the ontology class instances_
 
 
 
-URI: [nexus:Container](http://research.ibm.com/ontologies/aiont/Container)
+URI: [nexus:Container](https://ibm.github.io/risk-atlas-nexus/ontology/Container)
 
 
 
@@ -193,7 +193,7 @@ URI: [nexus:Container](http://research.ibm.com/ontologies/aiont/Container)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -221,12 +221,12 @@ URI: [nexus:Container](http://research.ibm.com/ontologies/aiont/Container)
 ```yaml
 name: Container
 description: An umbrella object that holds the ontology class instances
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 attributes:
   organizations:
     name: organizations
     description: A list of organizations
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -237,7 +237,7 @@ attributes:
   licenses:
     name: licenses
     description: A list of licenses
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -248,7 +248,7 @@ attributes:
   modalities:
     name: modalities
     description: A list of AI modalities
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -259,7 +259,7 @@ attributes:
   aitasks:
     name: aitasks
     description: A list of AI tasks
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -270,7 +270,7 @@ attributes:
   documents:
     name: documents
     description: A list of documents
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -281,7 +281,7 @@ attributes:
   datasets:
     name: datasets
     description: A list of data sets
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -292,7 +292,7 @@ attributes:
   taxonomies:
     name: taxonomies
     description: A list of AI risk taxonomies
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -303,7 +303,7 @@ attributes:
   riskgroups:
     name: riskgroups
     description: A list of AI risk groups
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -314,7 +314,7 @@ attributes:
   risks:
     name: risks
     description: A list of AI risks
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -325,7 +325,7 @@ attributes:
   riskcontrols:
     name: riskcontrols
     description: A list of AI risk controls
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -336,7 +336,7 @@ attributes:
   actions:
     name: actions
     description: A list of risk related actions
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -347,7 +347,7 @@ attributes:
   evaluations:
     name: evaluations
     description: A list of AI evaluation methods
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -358,7 +358,7 @@ attributes:
   aimodelfamilies:
     name: aimodelfamilies
     description: A list of AI model families
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -369,7 +369,7 @@ attributes:
   aimodels:
     name: aimodels
     description: A list of AI models
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     domain_of:
     - Container
@@ -388,12 +388,12 @@ tree_root: true
 ```yaml
 name: Container
 description: An umbrella object that holds the ontology class instances
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 attributes:
   organizations:
     name: organizations
     description: A list of organizations
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: organizations
     owner: Container
@@ -406,7 +406,7 @@ attributes:
   licenses:
     name: licenses
     description: A list of licenses
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: licenses
     owner: Container
@@ -419,7 +419,7 @@ attributes:
   modalities:
     name: modalities
     description: A list of AI modalities
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: modalities
     owner: Container
@@ -432,7 +432,7 @@ attributes:
   aitasks:
     name: aitasks
     description: A list of AI tasks
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: aitasks
     owner: Container
@@ -445,7 +445,7 @@ attributes:
   documents:
     name: documents
     description: A list of documents
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: documents
     owner: Container
@@ -458,7 +458,7 @@ attributes:
   datasets:
     name: datasets
     description: A list of data sets
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: datasets
     owner: Container
@@ -471,7 +471,7 @@ attributes:
   taxonomies:
     name: taxonomies
     description: A list of AI risk taxonomies
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: taxonomies
     owner: Container
@@ -484,7 +484,7 @@ attributes:
   riskgroups:
     name: riskgroups
     description: A list of AI risk groups
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: riskgroups
     owner: Container
@@ -497,7 +497,7 @@ attributes:
   risks:
     name: risks
     description: A list of AI risks
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: risks
     owner: Container
@@ -510,7 +510,7 @@ attributes:
   riskcontrols:
     name: riskcontrols
     description: A list of AI risk controls
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: riskcontrols
     owner: Container
@@ -523,7 +523,7 @@ attributes:
   actions:
     name: actions
     description: A list of risk related actions
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: actions
     owner: Container
@@ -536,7 +536,7 @@ attributes:
   evaluations:
     name: evaluations
     description: A list of AI evaluation methods
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: evaluations
     owner: Container
@@ -549,7 +549,7 @@ attributes:
   aimodelfamilies:
     name: aimodelfamilies
     description: A list of AI model families
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: aimodelfamilies
     owner: Container
@@ -562,7 +562,7 @@ attributes:
   aimodels:
     name: aimodels
     description: A list of AI models
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: aimodels
     owner: Container

--- a/docs/ontology/Curie.md
+++ b/docs/ontology/Curie.md
@@ -38,7 +38,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/DataPreprocessing.md
+++ b/docs/ontology/DataPreprocessing.md
@@ -9,7 +9,7 @@ _Data transformations, such as PI filtering, performed to ensure high quality of
 
 
 
-URI: [nexus:DataPreprocessing](http://research.ibm.com/ontologies/aiont/DataPreprocessing)
+URI: [nexus:DataPreprocessing](https://ibm.github.io/risk-atlas-nexus/ontology/DataPreprocessing)
 
 
 
@@ -79,7 +79,7 @@ URI: [nexus:DataPreprocessing](http://research.ibm.com/ontologies/aiont/DataPrep
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -108,7 +108,7 @@ URI: [nexus:DataPreprocessing](http://research.ibm.com/ontologies/aiont/DataPrep
 name: DataPreprocessing
 description: Data transformations, such as PI filtering, performed to ensure high
   quality of AI model training data.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiLifecyclePhase
 
 ```
@@ -121,14 +121,14 @@ is_a: AiLifecyclePhase
 name: DataPreprocessing
 description: Data transformations, such as PI filtering, performed to ensure high
   quality of AI model training data.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiLifecyclePhase
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -141,7 +141,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -152,7 +152,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -163,7 +163,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -174,7 +174,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -186,7 +186,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Dataset.md
+++ b/docs/ontology/Dataset.md
@@ -119,7 +119,7 @@ URI: [schema:Dataset](http://schema.org/Dataset)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -147,7 +147,7 @@ URI: [schema:Dataset](http://schema.org/Dataset)
 ```yaml
 name: Dataset
 description: A body of structured information describing some topic(s) of interest.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - hasLicense
@@ -164,13 +164,13 @@ class_uri: schema:Dataset
 ```yaml
 name: Dataset
 description: A body of structured information describing some topic(s) of interest.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -184,7 +184,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -202,7 +202,7 @@ attributes:
   provider:
     name: provider
     description: A relationship to the Organization instance that provides this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:provider
     alias: provider
@@ -214,7 +214,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -227,7 +227,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -238,7 +238,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -249,7 +249,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -260,7 +260,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -272,7 +272,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Date.md
+++ b/docs/ontology/Date.md
@@ -33,7 +33,7 @@ URI: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/DateOrDatetime.md
+++ b/docs/ontology/DateOrDatetime.md
@@ -33,7 +33,7 @@ URI: [linkml:DateOrDatetime](https://w3id.org/linkml/DateOrDatetime)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Datetime.md
+++ b/docs/ontology/Datetime.md
@@ -33,7 +33,7 @@ URI: [xsd:dateTime](http://www.w3.org/2001/XMLSchema#dateTime)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Decimal.md
+++ b/docs/ontology/Decimal.md
@@ -32,7 +32,7 @@ URI: [xsd:decimal](http://www.w3.org/2001/XMLSchema#decimal)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Documentation.md
+++ b/docs/ontology/Documentation.md
@@ -97,7 +97,7 @@ URI: [airo:Documentation](https://w3id.org/airo#Documentation)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -125,7 +125,7 @@ URI: [airo:Documentation](https://w3id.org/airo#Documentation)
 ```yaml
 name: Documentation
 description: Documented information about a concept or other topic(s) of interest.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 class_uri: airo:Documentation
 
@@ -138,14 +138,14 @@ class_uri: airo:Documentation
 ```yaml
 name: Documentation
 description: Documented information about a concept or other topic(s) of interest.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -158,7 +158,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -169,7 +169,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -180,7 +180,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -191,7 +191,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -203,7 +203,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Double.md
+++ b/docs/ontology/Double.md
@@ -32,7 +32,7 @@ URI: [xsd:double](http://www.w3.org/2001/XMLSchema#double)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Entity.md
+++ b/docs/ontology/Entity.md
@@ -128,7 +128,7 @@ URI: [schema:Thing](http://schema.org/Thing)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -156,7 +156,7 @@ URI: [schema:Thing](http://schema.org/Thing)
 ```yaml
 name: Entity
 description: A generic grouping for any identifiable entity.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 abstract: true
 slots:
 - id
@@ -176,14 +176,14 @@ class_uri: schema:Thing
 ```yaml
 name: Entity
 description: A generic grouping for any identifiable entity.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 abstract: true
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -196,7 +196,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -207,7 +207,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -218,7 +218,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -229,7 +229,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -241,7 +241,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/EuAiRiskCategory.md
+++ b/docs/ontology/EuAiRiskCategory.md
@@ -38,7 +38,7 @@ URI: [EuAiRiskCategory](EuAiRiskCategory.md)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -50,7 +50,7 @@ URI: [EuAiRiskCategory](EuAiRiskCategory.md)
 <details>
 ```yaml
 name: EuAiRiskCategory
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 permissible_values:
   MINIMAL:

--- a/docs/ontology/Fact.md
+++ b/docs/ontology/Fact.md
@@ -64,7 +64,7 @@ URI: [schema:Statement](http://schema.org/Statement)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -93,7 +93,7 @@ URI: [schema:Statement](http://schema.org/Statement)
 name: Fact
 description: A fact about something, for example the result of a measurement. In addition
   to the value, evidence is provided.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 abstract: true
 slots:
 - value
@@ -110,13 +110,13 @@ class_uri: schema:Statement
 name: Fact
 description: A fact about something, for example the result of a measurement. In addition
   to the value, evidence is provided.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 abstract: true
 attributes:
   value:
     name: value
     description: Some numeric or string value
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: value
     owner: Fact
@@ -128,7 +128,7 @@ attributes:
     name: evidence
     description: Evidence provides a source (typical a chunk, paragraph or link) describing
       where some value was found or how it was generated.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: evidence
     owner: Fact

--- a/docs/ontology/Float.md
+++ b/docs/ontology/Float.md
@@ -32,7 +32,7 @@ URI: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Integer.md
+++ b/docs/ontology/Integer.md
@@ -32,7 +32,7 @@ URI: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Jsonpath.md
+++ b/docs/ontology/Jsonpath.md
@@ -33,7 +33,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Jsonpointer.md
+++ b/docs/ontology/Jsonpointer.md
@@ -33,7 +33,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/LargeLanguageModel.md
+++ b/docs/ontology/LargeLanguageModel.md
@@ -9,7 +9,7 @@ _A large language model (LLM) is an AI model which supports a range of language-
 
 
 
-URI: [nexus:LargeLanguageModel](http://research.ibm.com/ontologies/aiont/LargeLanguageModel)
+URI: [nexus:LargeLanguageModel](https://ibm.github.io/risk-atlas-nexus/ontology/LargeLanguageModel)
 
 
 
@@ -232,7 +232,7 @@ URI: [nexus:LargeLanguageModel](http://research.ibm.com/ontologies/aiont/LargeLa
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -263,7 +263,7 @@ description: A large language model (LLM) is an AI model which supports a range 
   language-related tasks such as generation, summarization, classification, among
   others. A LLM is implemented as an artificial neural networks using a transformer
   architecture.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 aliases:
 - LLM
 is_a: AiModel
@@ -295,7 +295,7 @@ description: A large language model (LLM) is an AI model which supports a range 
   language-related tasks such as generation, summarization, classification, among
   others. A LLM is implemented as an artificial neural networks using a transformer
   architecture.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 aliases:
 - LLM
 is_a: AiModel
@@ -308,7 +308,7 @@ attributes:
   numParameters:
     name: numParameters
     description: A property indicating the number of parameters in a LLM.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: numParameters
     owner: LargeLanguageModel
@@ -319,7 +319,7 @@ attributes:
   numTrainingTokens:
     name: numTrainingTokens
     description: The number of tokens a AI model was trained on.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: numTrainingTokens
     owner: LargeLanguageModel
@@ -330,7 +330,7 @@ attributes:
   contextWindowSize:
     name: contextWindowSize
     description: The total length, in bytes, of an AI model's context window.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: contextWindowSize
     owner: LargeLanguageModel
@@ -342,7 +342,7 @@ attributes:
     name: hasInputModality
     description: A relationship indicating the input modalities supported by an AI
       component. Examples include text, image, video.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasInputModality
     owner: LargeLanguageModel
@@ -355,7 +355,7 @@ attributes:
     name: hasOutputModality
     description: A relationship indicating the output modalities supported by an AI
       component. Examples include text, image, video.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasOutputModality
     owner: LargeLanguageModel
@@ -367,7 +367,7 @@ attributes:
   hasTrainingData:
     name: hasTrainingData
     description: A relationship indicating the datasets an AI model was trained on.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasTrainingData
     alias: hasTrainingData
@@ -380,7 +380,7 @@ attributes:
   fine_tuning:
     name: fine_tuning
     description: A description of the fine-tuning mechanism(s) applied to a model.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: fine_tuning
     owner: LargeLanguageModel
@@ -391,7 +391,7 @@ attributes:
     name: supported_languages
     description: A list of languages, expressed as ISO two letter codes. For example,
       'jp, fr, en, de'
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: supported_languages
     owner: LargeLanguageModel
@@ -404,7 +404,7 @@ attributes:
   isPartOf:
     name: isPartOf
     description: Annotation that a Large Language model is part of a family of models
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isPartOf
@@ -416,7 +416,7 @@ attributes:
   hasEvaluation:
     name: hasEvaluation
     description: A relationship indicating that an entity has an AI evaluation result.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: dqv:hasQualityMeasurement
     alias: hasEvaluation
@@ -430,7 +430,7 @@ attributes:
   architecture:
     name: architecture
     description: A description of the architecture of an AI such as 'Decoder-only'.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: architecture
     owner: LargeLanguageModel
@@ -440,7 +440,7 @@ attributes:
   gpu_hours:
     name: gpu_hours
     description: GPU consumption in terms of hours
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: gpu_hours
     owner: LargeLanguageModel
@@ -451,7 +451,7 @@ attributes:
   power_consumption_w:
     name: power_consumption_w
     description: power consumption in Watts
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: power_consumption_w
     owner: LargeLanguageModel
@@ -463,7 +463,7 @@ attributes:
     name: carbon_emitted
     description: The number of tons of carbon dioxide equivalent that are emitted
       during training
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: carbon_emitted
     owner: LargeLanguageModel
@@ -478,7 +478,7 @@ attributes:
     name: hasRiskControl
     description: Indicates the control measures associated with a system or component
       to modify risks.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasRiskControl
     alias: hasRiskControl
@@ -490,7 +490,7 @@ attributes:
   producer:
     name: producer
     description: A relationship to the Organization instance which produces this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: producer
     owner: LargeLanguageModel
@@ -500,7 +500,7 @@ attributes:
   hasModelCard:
     name: hasModelCard
     description: A relationship to model card references.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasModelCard
     owner: LargeLanguageModel
@@ -513,7 +513,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -531,7 +531,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -545,7 +545,7 @@ attributes:
   performsTask:
     name: performsTask
     description: relationship indicating the AI tasks an AI model can perform.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: performsTask
     owner: LargeLanguageModel
@@ -558,7 +558,7 @@ attributes:
     name: isProvidedBy
     description: A relationship indicating the AI model has been provided by an AI
       model provider.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:isProvidedBy
     alias: isProvidedBy
@@ -570,7 +570,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -583,7 +583,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -594,7 +594,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -605,7 +605,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -616,7 +616,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -628,7 +628,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/LargeLanguageModelFamily.md
+++ b/docs/ontology/LargeLanguageModelFamily.md
@@ -9,7 +9,7 @@ _A large language model family is a set of models that are provided by the same 
 
 
 
-URI: [nexus:LargeLanguageModelFamily](http://research.ibm.com/ontologies/aiont/LargeLanguageModelFamily)
+URI: [nexus:LargeLanguageModelFamily](https://ibm.github.io/risk-atlas-nexus/ontology/LargeLanguageModelFamily)
 
 
 
@@ -96,7 +96,7 @@ URI: [nexus:LargeLanguageModelFamily](http://research.ibm.com/ontologies/aiont/L
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -127,7 +127,7 @@ description: A large language model family is a set of models that are provided 
   the same AI systems provider and are built around the same architecture, but differ
   e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite
   models.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - hasDocumentation
@@ -144,13 +144,13 @@ description: A large language model family is a set of models that are provided 
   the same AI systems provider and are built around the same architecture, but differ
   e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite
   models.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -169,7 +169,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -182,7 +182,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -193,7 +193,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -204,7 +204,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -215,7 +215,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -227,7 +227,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/License.md
+++ b/docs/ontology/License.md
@@ -101,7 +101,7 @@ URI: [airo:License](https://w3id.org/airo#License)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -130,7 +130,7 @@ URI: [airo:License](https://w3id.org/airo#License)
 name: License
 description: The general notion of a license which defines terms and grants permissions
   to users of AI systems, datasets and software.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - version
@@ -146,13 +146,13 @@ class_uri: airo:License
 name: License
 description: The general notion of a license which defines terms and grants permissions
   to users of AI systems, datasets and software.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   version:
     name: version
     description: The version of the entity embodied by a specified resource.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:version
     alias: version
@@ -165,7 +165,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -178,7 +178,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -189,7 +189,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -200,7 +200,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -211,7 +211,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -223,7 +223,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Modality.md
+++ b/docs/ontology/Modality.md
@@ -87,7 +87,7 @@ URI: [airo:Modality](https://w3id.org/airo#Modality)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -116,7 +116,7 @@ URI: [airo:Modality](https://w3id.org/airo#Modality)
 name: Modality
 description: A modality supported by an Ai component. Examples include text, image,
   video.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 class_uri: airo:Modality
 
@@ -130,14 +130,14 @@ class_uri: airo:Modality
 name: Modality
 description: A modality supported by an Ai component. Examples include text, image,
   video.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -150,7 +150,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -161,7 +161,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -172,7 +172,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -183,7 +183,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -195,7 +195,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Ncname.md
+++ b/docs/ontology/Ncname.md
@@ -33,7 +33,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Nodeidentifier.md
+++ b/docs/ontology/Nodeidentifier.md
@@ -33,7 +33,7 @@ URI: [shex:nonLiteral](http://www.w3.org/ns/shex#nonLiteral)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Objectidentifier.md
+++ b/docs/ontology/Objectidentifier.md
@@ -37,7 +37,7 @@ URI: [shex:iri](http://www.w3.org/ns/shex#iri)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Organization.md
+++ b/docs/ontology/Organization.md
@@ -110,7 +110,7 @@ URI: [schema:Organization](http://schema.org/Organization)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -139,7 +139,7 @@ URI: [schema:Organization](http://schema.org/Organization)
 name: Organization
 description: Any organizational entity such as a corporation, educational institution,
   consortium, government, etc.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - grants_license
@@ -155,14 +155,14 @@ class_uri: schema:Organization
 name: Organization
 description: Any organizational entity such as a corporation, educational institution,
   consortium, government, etc.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   grants_license:
     name: grants_license
     description: A relationship from a granting entity such as an Organization to
       a License instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: grants_license
     owner: Organization
@@ -173,7 +173,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -186,7 +186,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -197,7 +197,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -208,7 +208,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -219,7 +219,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -231,7 +231,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Question.md
+++ b/docs/ontology/Question.md
@@ -9,7 +9,7 @@ _An evaluation where a question has to be answered_
 
 
 
-URI: [nexus:Question](http://research.ibm.com/ontologies/aiont/Question)
+URI: [nexus:Question](https://ibm.github.io/risk-atlas-nexus/ontology/Question)
 
 
 
@@ -128,7 +128,7 @@ URI: [nexus:Question](http://research.ibm.com/ontologies/aiont/Question)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -156,13 +156,13 @@ URI: [nexus:Question](http://research.ibm.com/ontologies/aiont/Question)
 ```yaml
 name: Question
 description: An evaluation where a question has to be answered
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiEval
 attributes:
   text:
     name: text
     description: The question itself
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_eval
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval
     rank: 1000
     domain_of:
     - Question
@@ -177,13 +177,13 @@ attributes:
 ```yaml
 name: Question
 description: An evaluation where a question has to be answered
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiEval
 attributes:
   text:
     name: text
     description: The question itself
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_eval
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval
     rank: 1000
     alias: text
     owner: Question
@@ -194,7 +194,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -212,7 +212,7 @@ attributes:
   hasDataset:
     name: hasDataset
     description: A relationship to datasets that are used.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasDataset
     owner: Question
@@ -224,7 +224,7 @@ attributes:
   hasUnitxtCard:
     name: hasUnitxtCard
     description: A relationship to a Unitxt card defining the risk evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: hasUnitxtCard
@@ -235,7 +235,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -249,7 +249,7 @@ attributes:
   hasRelatedRisk:
     name: hasRelatedRisk
     description: A relationship where an entity relates to a risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasRelatedRisk
     owner: Question
@@ -262,7 +262,7 @@ attributes:
   bestValue:
     name: bestValue
     description: Annotation of the best possible result of the evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: bestValue
     owner: Question
@@ -273,7 +273,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -286,7 +286,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -297,7 +297,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -308,7 +308,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -319,7 +319,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -331,7 +331,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Questionnaire.md
+++ b/docs/ontology/Questionnaire.md
@@ -9,7 +9,7 @@ _A questionnaire groups questions_
 
 
 
-URI: [nexus:Questionnaire](http://research.ibm.com/ontologies/aiont/Questionnaire)
+URI: [nexus:Questionnaire](https://ibm.github.io/risk-atlas-nexus/ontology/Questionnaire)
 
 
 
@@ -125,7 +125,7 @@ URI: [nexus:Questionnaire](http://research.ibm.com/ontologies/aiont/Questionnair
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -153,7 +153,7 @@ URI: [nexus:Questionnaire](http://research.ibm.com/ontologies/aiont/Questionnair
 ```yaml
 name: Questionnaire
 description: A questionnaire groups questions
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiEval
 slot_usage:
   composed_of:
@@ -169,7 +169,7 @@ slot_usage:
 ```yaml
 name: Questionnaire
 description: A questionnaire groups questions
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: AiEval
 slot_usage:
   composed_of:
@@ -179,7 +179,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -197,7 +197,7 @@ attributes:
   hasDataset:
     name: hasDataset
     description: A relationship to datasets that are used.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasDataset
     owner: Questionnaire
@@ -209,7 +209,7 @@ attributes:
   hasUnitxtCard:
     name: hasUnitxtCard
     description: A relationship to a Unitxt card defining the risk evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: hasUnitxtCard
@@ -220,7 +220,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -234,7 +234,7 @@ attributes:
   hasRelatedRisk:
     name: hasRelatedRisk
     description: A relationship where an entity relates to a risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasRelatedRisk
     owner: Questionnaire
@@ -247,7 +247,7 @@ attributes:
   bestValue:
     name: bestValue
     description: Annotation of the best possible result of the evaluation
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: bestValue
     owner: Questionnaire
@@ -258,7 +258,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -271,7 +271,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -282,7 +282,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -293,7 +293,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -304,7 +304,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -316,7 +316,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Risk.md
+++ b/docs/ontology/Risk.md
@@ -217,7 +217,7 @@ URI: [airo:Risk](https://w3id.org/airo#Risk)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -246,7 +246,7 @@ URI: [airo:Risk](https://w3id.org/airo#Risk)
 name: Risk
 description: The state of uncertainty associated with an AI system, that has the potential
   to cause harms
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - RiskConcept
@@ -269,14 +269,14 @@ attributes:
   tag:
     name: tag
     description: A shost version of the name
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     domain_of:
     - Risk
   type:
     name: type
     description: Annotation whether an AI risk occurs at input or output or is non-technical.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     domain_of:
     - Risk
@@ -284,7 +284,7 @@ attributes:
     name: phase
     description: Annotation whether an AI risk shows specifically during the training-tuning
       or inference phase.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     domain_of:
     - Risk
@@ -292,14 +292,14 @@ attributes:
     name: descriptor
     description: Annotates whether an AI risk is a traditional risk, specific to or
       amplified by AI.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     domain_of:
     - Risk
   concern:
     name: concern
     description: Some explanation about the concern related to an AI risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     domain_of:
     - Risk
@@ -315,7 +315,7 @@ class_uri: airo:Risk
 name: Risk
 description: The state of uncertainty associated with an AI system, that has the potential
   to cause harms
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - RiskConcept
@@ -328,7 +328,7 @@ attributes:
   tag:
     name: tag
     description: A shost version of the name
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     alias: tag
     owner: Risk
@@ -338,7 +338,7 @@ attributes:
   type:
     name: type
     description: Annotation whether an AI risk occurs at input or output or is non-technical.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     alias: type
     owner: Risk
@@ -349,7 +349,7 @@ attributes:
     name: phase
     description: Annotation whether an AI risk shows specifically during the training-tuning
       or inference phase.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     alias: phase
     owner: Risk
@@ -360,7 +360,7 @@ attributes:
     name: descriptor
     description: Annotates whether an AI risk is a traditional risk, specific to or
       amplified by AI.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     alias: descriptor
     owner: Risk
@@ -370,7 +370,7 @@ attributes:
   concern:
     name: concern
     description: Some explanation about the concern related to an AI risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai_risk
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
     rank: 1000
     alias: concern
     owner: Risk
@@ -380,7 +380,7 @@ attributes:
   hasRelatedAction:
     name: hasRelatedAction
     description: A relationship where an entity relates to an action
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: hasRelatedAction
     owner: Risk
@@ -393,7 +393,7 @@ attributes:
     name: isDefinedByTaxonomy
     description: A relationship where a risk or a risk group is defined by a risk
       taxonomy
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isDefinedByTaxonomy
@@ -407,7 +407,7 @@ attributes:
   isPartOf:
     name: isPartOf
     description: A relationship where a risk is part of a risk group
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isPartOf
@@ -420,7 +420,7 @@ attributes:
     name: closeMatch
     description: The property is used to link two concepts that are sufficiently similar
       that they can be used interchangeably in some information retrieval applications.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:closeMatch
     alias: closeMatch
@@ -439,7 +439,7 @@ attributes:
     description: The property is used to link two concepts, indicating a high degree
       of confidence that the concepts can be used interchangeably across a wide range
       of information retrieval applications
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:exactMatch
     alias: exactMatch
@@ -458,7 +458,7 @@ attributes:
     description: The property is used to state a hierarchical mapping link between
       two concepts, indicating that the concept linked to, is a broader concept than
       the originating concept.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:broadMatch
     alias: broadMatch
@@ -477,7 +477,7 @@ attributes:
     description: The property is used to state a hierarchical mapping link between
       two concepts, indicating that the concept linked to, is a narrower concept than
       the originating concept.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:narrowMatch
     alias: narrowMatch
@@ -495,7 +495,7 @@ attributes:
     name: relatedMatch
     description: The property skos:relatedMatch is used to state an associative mapping
       link between two concepts.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:relatedMatch
     alias: relatedMatch
@@ -513,7 +513,7 @@ attributes:
     name: detectsRiskConcept
     description: The property airo:detectsRiskConcept indicates the control used for
       detecting risks, risk sources,  consequences, and impacts.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     exact_mappings:
     - airo:detectsRiskConcept
     rank: 1000
@@ -530,7 +530,7 @@ attributes:
     name: isDetectedBy
     description: A relationship where a risk, risk source, consequence, or impact
       is detected by a risk control.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: isDetectedBy
     owner: Risk
@@ -544,7 +544,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -557,7 +557,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -568,7 +568,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -579,7 +579,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -590,7 +590,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -602,7 +602,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/RiskConcept.md
+++ b/docs/ontology/RiskConcept.md
@@ -103,7 +103,7 @@ URI: [airo:RiskConcept](https://w3id.org/airo#RiskConcept)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -131,7 +131,7 @@ URI: [airo:RiskConcept](https://w3id.org/airo#RiskConcept)
 ```yaml
 name: RiskConcept
 description: An umbrella term for refering to risk, risk source, consequence and impact.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - isDetectedBy
@@ -146,14 +146,14 @@ class_uri: airo:RiskConcept
 ```yaml
 name: RiskConcept
 description: An umbrella term for refering to risk, risk source, consequence and impact.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   isDetectedBy:
     name: isDetectedBy
     description: A relationship where a risk, risk source, consequence, or impact
       is detected by a risk control.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: isDetectedBy
     owner: RiskConcept
@@ -167,7 +167,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -180,7 +180,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -191,7 +191,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -202,7 +202,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -213,7 +213,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -225,7 +225,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/RiskControl.md
+++ b/docs/ontology/RiskControl.md
@@ -110,7 +110,7 @@ URI: [airo:RiskControl](https://w3id.org/airo#RiskControl)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -138,7 +138,7 @@ URI: [airo:RiskControl](https://w3id.org/airo#RiskControl)
 ```yaml
 name: RiskControl
 description: A measure that maintains and/or modifies risk (and risk concepts)
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - detectsRiskConcept
@@ -154,14 +154,14 @@ class_uri: airo:RiskControl
 ```yaml
 name: RiskControl
 description: A measure that maintains and/or modifies risk (and risk concepts)
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   detectsRiskConcept:
     name: detectsRiskConcept
     description: The property airo:detectsRiskConcept indicates the control used for
       detecting risks, risk sources,  consequences, and impacts.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     exact_mappings:
     - airo:detectsRiskConcept
     rank: 1000
@@ -178,7 +178,7 @@ attributes:
     name: isDefinedByTaxonomy
     description: A relationship where a risk or a risk group is defined by a risk
       taxonomy
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isDefinedByTaxonomy
@@ -193,7 +193,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -206,7 +206,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -217,7 +217,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -228,7 +228,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -239,7 +239,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -251,7 +251,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/RiskGroup.md
+++ b/docs/ontology/RiskGroup.md
@@ -9,7 +9,7 @@ _A group of AI system related risks that are part of a risk taxonomy._
 
 
 
-URI: [nexus:RiskGroup](http://research.ibm.com/ontologies/aiont/RiskGroup)
+URI: [nexus:RiskGroup](https://ibm.github.io/risk-atlas-nexus/ontology/RiskGroup)
 
 
 
@@ -178,7 +178,7 @@ URI: [nexus:RiskGroup](http://research.ibm.com/ontologies/aiont/RiskGroup)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -206,7 +206,7 @@ URI: [nexus:RiskGroup](http://research.ibm.com/ontologies/aiont/RiskGroup)
 ```yaml
 name: RiskGroup
 description: A group of AI system related risks that are part of a risk taxonomy.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - RiskConcept
@@ -233,7 +233,7 @@ slot_usage:
 ```yaml
 name: RiskGroup
 description: A group of AI system related risks that are part of a risk taxonomy.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 mixins:
 - RiskConcept
@@ -247,7 +247,7 @@ attributes:
     name: isDefinedByTaxonomy
     description: A relationship where a risk or a risk group is defined by a risk
       taxonomy
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:isPartOf
     alias: isDefinedByTaxonomy
@@ -262,7 +262,7 @@ attributes:
     name: closeMatch
     description: The property is used to link two concepts that are sufficiently similar
       that they can be used interchangeably in some information retrieval applications.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:closeMatch
     alias: closeMatch
@@ -281,7 +281,7 @@ attributes:
     description: The property is used to link two concepts, indicating a high degree
       of confidence that the concepts can be used interchangeably across a wide range
       of information retrieval applications
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:exactMatch
     alias: exactMatch
@@ -300,7 +300,7 @@ attributes:
     description: The property is used to state a hierarchical mapping link between
       two concepts, indicating that the concept linked to, is a broader concept than
       the originating concept.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:broadMatch
     alias: broadMatch
@@ -319,7 +319,7 @@ attributes:
     description: The property is used to state a hierarchical mapping link between
       two concepts, indicating that the concept linked to, is a narrower concept than
       the originating concept.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:narrowMatch
     alias: narrowMatch
@@ -337,7 +337,7 @@ attributes:
     name: relatedMatch
     description: The property skos:relatedMatch is used to state an associative mapping
       link between two concepts.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: skos:relatedMatch
     alias: relatedMatch
@@ -354,7 +354,7 @@ attributes:
   hasPart:
     name: hasPart
     description: A relationship where a riskgroup has a risk
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:hasPart
     alias: hasPart
@@ -367,7 +367,7 @@ attributes:
     name: isDetectedBy
     description: A relationship where a risk, risk source, consequence, or impact
       is detected by a risk control.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     alias: isDetectedBy
     owner: RiskGroup
@@ -381,7 +381,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -394,7 +394,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -405,7 +405,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -416,7 +416,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -427,7 +427,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -439,7 +439,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/RiskTaxonomy.md
+++ b/docs/ontology/RiskTaxonomy.md
@@ -9,7 +9,7 @@ _A taxonomy of AI system related risks_
 
 
 
-URI: [nexus:RiskTaxonomy](http://research.ibm.com/ontologies/aiont/RiskTaxonomy)
+URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
 
 
 
@@ -112,7 +112,7 @@ URI: [nexus:RiskTaxonomy](http://research.ibm.com/ontologies/aiont/RiskTaxonomy)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -140,7 +140,7 @@ URI: [nexus:RiskTaxonomy](http://research.ibm.com/ontologies/aiont/RiskTaxonomy)
 ```yaml
 name: RiskTaxonomy
 description: A taxonomy of AI system related risks
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 slots:
 - version
@@ -156,13 +156,13 @@ slots:
 ```yaml
 name: RiskTaxonomy
 description: A taxonomy of AI system related risks
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
   version:
     name: version
     description: The version of the entity embodied by a specified resource.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:version
     alias: version
@@ -174,7 +174,7 @@ attributes:
   hasDocumentation:
     name: hasDocumentation
     description: Indicates documentation associated with an entity.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasDocumentation
     alias: hasDocumentation
@@ -192,7 +192,7 @@ attributes:
   hasLicense:
     name: hasLicense
     description: Indicates licenses associated with a resource
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: airo:hasLicense
     alias: hasLicense
@@ -207,7 +207,7 @@ attributes:
     name: id
     description: A unique identifier to this instance of the model element. Example
       identifiers include UUID, URI, URN, etc.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:identifier
     identifier: true
@@ -220,7 +220,7 @@ attributes:
   name:
     name: name
     description: A text name of this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:name
     alias: name
@@ -231,7 +231,7 @@ attributes:
   description:
     name: description
     description: The description of an entity
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:description
     alias: description
@@ -242,7 +242,7 @@ attributes:
   url:
     name: url
     description: An optional URL associated with this instance.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:url
     alias: url
@@ -253,7 +253,7 @@ attributes:
   dateCreated:
     name: dateCreated
     description: The date on which the entity was created.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
@@ -265,7 +265,7 @@ attributes:
   dateModified:
     name: dateModified
     description: The date on which the entity was most recently modified.
-    from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified

--- a/docs/ontology/Sparqlpath.md
+++ b/docs/ontology/Sparqlpath.md
@@ -33,7 +33,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/String.md
+++ b/docs/ontology/String.md
@@ -32,7 +32,7 @@ URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Time.md
+++ b/docs/ontology/Time.md
@@ -33,7 +33,7 @@ URI: [xsd:time](http://www.w3.org/2001/XMLSchema#time)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Uri.md
+++ b/docs/ontology/Uri.md
@@ -37,7 +37,7 @@ URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/Uriorcurie.md
+++ b/docs/ontology/Uriorcurie.md
@@ -33,7 +33,7 @@ URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 

--- a/docs/ontology/actions.md
+++ b/docs/ontology/actions.md
@@ -9,7 +9,7 @@ _A list of risk related actions_
 
 
 
-URI: [nexus:actions](http://research.ibm.com/ontologies/aiont/actions)
+URI: [nexus:actions](https://ibm.github.io/risk-atlas-nexus/ontology/actions)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:actions](http://research.ibm.com/ontologies/aiont/actions)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:actions](http://research.ibm.com/ontologies/aiont/actions)
 ```yaml
 name: actions
 description: A list of risk related actions
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: actions
 owner: Container

--- a/docs/ontology/ai-risk-ontology.md
+++ b/docs/ontology/ai-risk-ontology.md
@@ -2,5 +2,5 @@
 
 An ontology describing AI systems and their risks
 
-URI: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+URI: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 

--- a/docs/ontology/aiActorTask.md
+++ b/docs/ontology/aiActorTask.md
@@ -9,7 +9,7 @@ _Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed w
 
 
 
-URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorTask)
+URI: [nexus:hasAiActorTask](https://ibm.github.io/risk-atlas-nexus/ontology/hasAiActorTask)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorT
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ name: hasAiActorTask
 description: Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task
   listed will apply to every suggested action in the subcategory (i.e., some apply
   to AI development and others apply to AI deployment).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasAiActorTask
 owner: Action

--- a/docs/ontology/ai_actor_task.md
+++ b/docs/ontology/ai_actor_task.md
@@ -9,7 +9,7 @@ _Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed w
 
 
 
-URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorTask)
+URI: [nexus:hasAiActorTask](https://ibm.github.io/risk-atlas-nexus/ontology/hasAiActorTask)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorT
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ name: hasAiActorTask
 description: Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task
   listed will apply to every suggested action in the subcategory (i.e., some apply
   to AI development and others apply to AI deployment).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasAiActorTask
 owner: Action

--- a/docs/ontology/ai_risk.md
+++ b/docs/ontology/ai_risk.md
@@ -2,5 +2,5 @@
 
 Vocabulary describing AI risks as used by IBM Risk Atlas
 
-URI: http://research.ibm.com/ontologies/aiont/ai_risk
+URI: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
 

--- a/docs/ontology/aimodelfamilies.md
+++ b/docs/ontology/aimodelfamilies.md
@@ -9,7 +9,7 @@ _A list of AI model families_
 
 
 
-URI: [nexus:aimodelfamilies](http://research.ibm.com/ontologies/aiont/aimodelfamilies)
+URI: [nexus:aimodelfamilies](https://ibm.github.io/risk-atlas-nexus/ontology/aimodelfamilies)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:aimodelfamilies](http://research.ibm.com/ontologies/aiont/aimodelfam
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:aimodelfamilies](http://research.ibm.com/ontologies/aiont/aimodelfam
 ```yaml
 name: aimodelfamilies
 description: A list of AI model families
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: aimodelfamilies
 owner: Container

--- a/docs/ontology/aimodels.md
+++ b/docs/ontology/aimodels.md
@@ -9,7 +9,7 @@ _A list of AI models_
 
 
 
-URI: [nexus:aimodels](http://research.ibm.com/ontologies/aiont/aimodels)
+URI: [nexus:aimodels](https://ibm.github.io/risk-atlas-nexus/ontology/aimodels)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:aimodels](http://research.ibm.com/ontologies/aiont/aimodels)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:aimodels](http://research.ibm.com/ontologies/aiont/aimodels)
 ```yaml
 name: aimodels
 description: A list of AI models
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: aimodels
 owner: Container

--- a/docs/ontology/aitasks.md
+++ b/docs/ontology/aitasks.md
@@ -9,7 +9,7 @@ _A list of AI tasks_
 
 
 
-URI: [nexus:aitasks](http://research.ibm.com/ontologies/aiont/aitasks)
+URI: [nexus:aitasks](https://ibm.github.io/risk-atlas-nexus/ontology/aitasks)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:aitasks](http://research.ibm.com/ontologies/aiont/aitasks)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:aitasks](http://research.ibm.com/ontologies/aiont/aitasks)
 ```yaml
 name: aitasks
 description: A list of AI tasks
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: aitasks
 owner: Container

--- a/docs/ontology/architecture.md
+++ b/docs/ontology/architecture.md
@@ -9,7 +9,7 @@ _A description of the architecture of an AI such as 'Decoder-only'._
 
 
 
-URI: [nexus:architecture](http://research.ibm.com/ontologies/aiont/architecture)
+URI: [nexus:architecture](https://ibm.github.io/risk-atlas-nexus/ontology/architecture)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:architecture](http://research.ibm.com/ontologies/aiont/architecture)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -51,7 +51,7 @@ URI: [nexus:architecture](http://research.ibm.com/ontologies/aiont/architecture)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [nexus:architecture](http://research.ibm.com/ontologies/aiont/architecture)
 ```yaml
 name: architecture
 description: A description of the architecture of an AI such as 'Decoder-only'.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: architecture
 domain_of:

--- a/docs/ontology/bestValue.md
+++ b/docs/ontology/bestValue.md
@@ -9,7 +9,7 @@ _Annotation of the best possible result of the evaluation_
 
 
 
-URI: [nexus:bestValue](http://research.ibm.com/ontologies/aiont/bestValue)
+URI: [nexus:bestValue](https://ibm.github.io/risk-atlas-nexus/ontology/bestValue)
 
 
 
@@ -24,8 +24,8 @@ URI: [nexus:bestValue](http://research.ibm.com/ontologies/aiont/bestValue)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:bestValue](http://research.ibm.com/ontologies/aiont/bestValue)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:bestValue](http://research.ibm.com/ontologies/aiont/bestValue)
 ```yaml
 name: bestValue
 description: Annotation of the best possible result of the evaluation
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: bestValue
 domain_of:

--- a/docs/ontology/broadMatch.md
+++ b/docs/ontology/broadMatch.md
@@ -53,7 +53,7 @@ URI: [skos:broadMatch](http://www.w3.org/2004/02/skos/core/broadMatch)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ name: broadMatch
 description: The property is used to state a hierarchical mapping link between two
   concepts, indicating that the concept linked to, is a broader concept than the originating
   concept.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: skos:broadMatch
 alias: broadMatch

--- a/docs/ontology/carbon_emitted.md
+++ b/docs/ontology/carbon_emitted.md
@@ -9,7 +9,7 @@ _The number of tons of carbon dioxide equivalent that are emitted during trainin
 
 
 
-URI: [nexus:carbon_emitted](http://research.ibm.com/ontologies/aiont/carbon_emitted)
+URI: [nexus:carbon_emitted](https://ibm.github.io/risk-atlas-nexus/ontology/carbon_emitted)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:carbon_emitted](http://research.ibm.com/ontologies/aiont/carbon_emit
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [nexus:carbon_emitted](http://research.ibm.com/ontologies/aiont/carbon_emit
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [nexus:carbon_emitted](http://research.ibm.com/ontologies/aiont/carbon_emit
 name: carbon_emitted
 description: The number of tons of carbon dioxide equivalent that are emitted during
   training
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: carbon_emitted
 domain_of:

--- a/docs/ontology/closeMatch.md
+++ b/docs/ontology/closeMatch.md
@@ -53,7 +53,7 @@ URI: [skos:closeMatch](http://www.w3.org/2004/02/skos/core/closeMatch)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [skos:closeMatch](http://www.w3.org/2004/02/skos/core/closeMatch)
 name: closeMatch
 description: The property is used to link two concepts that are sufficiently similar
   that they can be used interchangeably in some information retrieval applications.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: skos:closeMatch
 alias: closeMatch

--- a/docs/ontology/concern.md
+++ b/docs/ontology/concern.md
@@ -9,7 +9,7 @@ _Some explanation about the concern related to an AI risk_
 
 
 
-URI: [nexus:concern](http://research.ibm.com/ontologies/aiont/concern)
+URI: [nexus:concern](https://ibm.github.io/risk-atlas-nexus/ontology/concern)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:concern](http://research.ibm.com/ontologies/aiont/concern)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [nexus:concern](http://research.ibm.com/ontologies/aiont/concern)
 ```yaml
 name: concern
 description: Some explanation about the concern related to an AI risk
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: concern
 owner: Risk

--- a/docs/ontology/contextWindowSize.md
+++ b/docs/ontology/contextWindowSize.md
@@ -9,7 +9,7 @@ _The total length, in bytes, of an AI model's context window._
 
 
 
-URI: [nexus:contextWindowSize](http://research.ibm.com/ontologies/aiont/contextWindowSize)
+URI: [nexus:contextWindowSize](https://ibm.github.io/risk-atlas-nexus/ontology/contextWindowSize)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:contextWindowSize](http://research.ibm.com/ontologies/aiont/contextW
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:contextWindowSize](http://research.ibm.com/ontologies/aiont/contextW
 ```yaml
 name: contextWindowSize
 description: The total length, in bytes, of an AI model's context window.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: contextWindowSize
 domain_of:

--- a/docs/ontology/datasets.md
+++ b/docs/ontology/datasets.md
@@ -9,7 +9,7 @@ _A list of data sets_
 
 
 
-URI: [nexus:datasets](http://research.ibm.com/ontologies/aiont/datasets)
+URI: [nexus:datasets](https://ibm.github.io/risk-atlas-nexus/ontology/datasets)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:datasets](http://research.ibm.com/ontologies/aiont/datasets)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:datasets](http://research.ibm.com/ontologies/aiont/datasets)
 ```yaml
 name: datasets
 description: A list of data sets
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: datasets
 owner: Container

--- a/docs/ontology/dateCreated.md
+++ b/docs/ontology/dateCreated.md
@@ -23,34 +23,34 @@ URI: [schema:dateCreated](http://schema.org/dateCreated)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -77,7 +77,7 @@ URI: [schema:dateCreated](http://schema.org/dateCreated)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -98,7 +98,7 @@ URI: [schema:dateCreated](http://schema.org/dateCreated)
 ```yaml
 name: dateCreated
 description: The date on which the entity was created.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:dateCreated
 alias: dateCreated

--- a/docs/ontology/dateModified.md
+++ b/docs/ontology/dateModified.md
@@ -23,34 +23,34 @@ URI: [schema:dateModified](http://schema.org/dateModified)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -77,7 +77,7 @@ URI: [schema:dateModified](http://schema.org/dateModified)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -98,7 +98,7 @@ URI: [schema:dateModified](http://schema.org/dateModified)
 ```yaml
 name: dateModified
 description: The date on which the entity was most recently modified.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:dateModified
 alias: dateModified

--- a/docs/ontology/description.md
+++ b/docs/ontology/description.md
@@ -23,34 +23,34 @@ URI: [schema:description](http://schema.org/description)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -77,7 +77,7 @@ URI: [schema:description](http://schema.org/description)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -98,7 +98,7 @@ URI: [schema:description](http://schema.org/description)
 ```yaml
 name: description
 description: The description of an entity
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:description
 alias: description

--- a/docs/ontology/descriptor.md
+++ b/docs/ontology/descriptor.md
@@ -9,7 +9,7 @@ _Annotates whether an AI risk is a traditional risk, specific to or amplified by
 
 
 
-URI: [nexus:descriptor](http://research.ibm.com/ontologies/aiont/descriptor)
+URI: [nexus:descriptor](https://ibm.github.io/risk-atlas-nexus/ontology/descriptor)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:descriptor](http://research.ibm.com/ontologies/aiont/descriptor)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [nexus:descriptor](http://research.ibm.com/ontologies/aiont/descriptor)
 name: descriptor
 description: Annotates whether an AI risk is a traditional risk, specific to or amplified
   by AI.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: descriptor
 owner: Risk

--- a/docs/ontology/detectsRiskConcept.md
+++ b/docs/ontology/detectsRiskConcept.md
@@ -9,7 +9,7 @@ _The property airo:detectsRiskConcept indicates the control used for detecting r
 
 
 
-URI: [nexus:detectsRiskConcept](http://research.ibm.com/ontologies/aiont/detectsRiskConcept)
+URI: [nexus:detectsRiskConcept](https://ibm.github.io/risk-atlas-nexus/ontology/detectsRiskConcept)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:detectsRiskConcept](http://research.ibm.com/ontologies/aiont/detects
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 | [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [nexus:detectsRiskConcept](http://research.ibm.com/ontologies/aiont/detects
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ URI: [nexus:detectsRiskConcept](http://research.ibm.com/ontologies/aiont/detects
 name: detectsRiskConcept
 description: The property airo:detectsRiskConcept indicates the control used for detecting
   risks, risk sources,  consequences, and impacts.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 exact_mappings:
 - airo:detectsRiskConcept
 rank: 1000

--- a/docs/ontology/documents.md
+++ b/docs/ontology/documents.md
@@ -9,7 +9,7 @@ _A list of documents_
 
 
 
-URI: [nexus:documents](http://research.ibm.com/ontologies/aiont/documents)
+URI: [nexus:documents](https://ibm.github.io/risk-atlas-nexus/ontology/documents)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:documents](http://research.ibm.com/ontologies/aiont/documents)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:documents](http://research.ibm.com/ontologies/aiont/documents)
 ```yaml
 name: documents
 description: A list of documents
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: documents
 owner: Container

--- a/docs/ontology/evaluations.md
+++ b/docs/ontology/evaluations.md
@@ -9,7 +9,7 @@ _A list of AI evaluation methods_
 
 
 
-URI: [nexus:evaluations](http://research.ibm.com/ontologies/aiont/evaluations)
+URI: [nexus:evaluations](https://ibm.github.io/risk-atlas-nexus/ontology/evaluations)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:evaluations](http://research.ibm.com/ontologies/aiont/evaluations)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:evaluations](http://research.ibm.com/ontologies/aiont/evaluations)
 ```yaml
 name: evaluations
 description: A list of AI evaluation methods
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: evaluations
 owner: Container

--- a/docs/ontology/evidence.md
+++ b/docs/ontology/evidence.md
@@ -9,7 +9,7 @@ _Evidence provides a source (typical a chunk, paragraph or link) describing wher
 
 
 
-URI: [nexus:evidence](http://research.ibm.com/ontologies/aiont/evidence)
+URI: [nexus:evidence](https://ibm.github.io/risk-atlas-nexus/ontology/evidence)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:evidence](http://research.ibm.com/ontologies/aiont/evidence)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 
 
 
@@ -51,7 +51,7 @@ URI: [nexus:evidence](http://research.ibm.com/ontologies/aiont/evidence)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:evidence](http://research.ibm.com/ontologies/aiont/evidence)
 name: evidence
 description: Evidence provides a source (typical a chunk, paragraph or link) describing
   where some value was found or how it was generated.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: evidence
 domain_of:

--- a/docs/ontology/exactMatch.md
+++ b/docs/ontology/exactMatch.md
@@ -53,7 +53,7 @@ URI: [skos:exactMatch](http://www.w3.org/2004/02/skos/core/exactMatch)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ name: exactMatch
 description: The property is used to link two concepts, indicating a high degree of
   confidence that the concepts can be used interchangeably across a wide range of
   information retrieval applications
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: skos:exactMatch
 alias: exactMatch

--- a/docs/ontology/fine_tuning.md
+++ b/docs/ontology/fine_tuning.md
@@ -9,7 +9,7 @@ _A description of the fine-tuning mechanism(s) applied to a model._
 
 
 
-URI: [nexus:fine_tuning](http://research.ibm.com/ontologies/aiont/fine_tuning)
+URI: [nexus:fine_tuning](https://ibm.github.io/risk-atlas-nexus/ontology/fine_tuning)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:fine_tuning](http://research.ibm.com/ontologies/aiont/fine_tuning)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [nexus:fine_tuning](http://research.ibm.com/ontologies/aiont/fine_tuning)
 ```yaml
 name: fine_tuning
 description: A description of the fine-tuning mechanism(s) applied to a model.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: fine_tuning
 domain_of:

--- a/docs/ontology/gpu_hours.md
+++ b/docs/ontology/gpu_hours.md
@@ -9,7 +9,7 @@ _GPU consumption in terms of hours_
 
 
 
-URI: [nexus:gpu_hours](http://research.ibm.com/ontologies/aiont/gpu_hours)
+URI: [nexus:gpu_hours](https://ibm.github.io/risk-atlas-nexus/ontology/gpu_hours)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:gpu_hours](http://research.ibm.com/ontologies/aiont/gpu_hours)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [nexus:gpu_hours](http://research.ibm.com/ontologies/aiont/gpu_hours)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:gpu_hours](http://research.ibm.com/ontologies/aiont/gpu_hours)
 ```yaml
 name: gpu_hours
 description: GPU consumption in terms of hours
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: gpu_hours
 domain_of:

--- a/docs/ontology/grants_license.md
+++ b/docs/ontology/grants_license.md
@@ -9,7 +9,7 @@ _A relationship from a granting entity such as an Organization to a License inst
 
 
 
-URI: [nexus:grants_license](http://research.ibm.com/ontologies/aiont/grants_license)
+URI: [nexus:grants_license](https://ibm.github.io/risk-atlas-nexus/ontology/grants_license)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:grants_license](http://research.ibm.com/ontologies/aiont/grants_lice
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
 | [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
 | [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
 
 
@@ -52,7 +52,7 @@ URI: [nexus:grants_license](http://research.ibm.com/ontologies/aiont/grants_lice
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:grants_license](http://research.ibm.com/ontologies/aiont/grants_lice
 name: grants_license
 description: A relationship from a granting entity such as an Organization to a License
   instance.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: grants_license
 domain_of:

--- a/docs/ontology/hasAiActorTask.md
+++ b/docs/ontology/hasAiActorTask.md
@@ -9,7 +9,7 @@ _Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed w
 
 
 
-URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorTask)
+URI: [nexus:hasAiActorTask](https://ibm.github.io/risk-atlas-nexus/ontology/hasAiActorTask)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasAiActorTask](http://research.ibm.com/ontologies/aiont/hasAiActorT
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ name: hasAiActorTask
 description: Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task
   listed will apply to every suggested action in the subcategory (i.e., some apply
   to AI development and others apply to AI deployment).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasAiActorTask
 domain_of:

--- a/docs/ontology/hasDataset.md
+++ b/docs/ontology/hasDataset.md
@@ -9,7 +9,7 @@ _A relationship to datasets that are used._
 
 
 
-URI: [nexus:hasDataset](http://research.ibm.com/ontologies/aiont/hasDataset)
+URI: [nexus:hasDataset](https://ibm.github.io/risk-atlas-nexus/ontology/hasDataset)
 
 
 
@@ -24,8 +24,8 @@ URI: [nexus:hasDataset](http://research.ibm.com/ontologies/aiont/hasDataset)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 
 
 
@@ -54,7 +54,7 @@ URI: [nexus:hasDataset](http://research.ibm.com/ontologies/aiont/hasDataset)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [nexus:hasDataset](http://research.ibm.com/ontologies/aiont/hasDataset)
 ```yaml
 name: hasDataset
 description: A relationship to datasets that are used.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasDataset
 domain_of:

--- a/docs/ontology/hasDocumentation.md
+++ b/docs/ontology/hasDocumentation.md
@@ -23,18 +23,18 @@ URI: [airo:hasDocumentation](https://w3id.org/airo#hasDocumentation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
 | [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
 
 
 
@@ -63,7 +63,7 @@ URI: [airo:hasDocumentation](https://w3id.org/airo#hasDocumentation)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -84,7 +84,7 @@ URI: [airo:hasDocumentation](https://w3id.org/airo#hasDocumentation)
 ```yaml
 name: hasDocumentation
 description: Indicates documentation associated with an entity.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: airo:hasDocumentation
 alias: hasDocumentation

--- a/docs/ontology/hasEuAiSystemType.md
+++ b/docs/ontology/hasEuAiSystemType.md
@@ -9,7 +9,7 @@ _The type of system as defined by the EU AI Act._
 
 
 
-URI: [nexus:hasEuAiSystemType](http://research.ibm.com/ontologies/aiont/hasEuAiSystemType)
+URI: [nexus:hasEuAiSystemType](https://ibm.github.io/risk-atlas-nexus/ontology/hasEuAiSystemType)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:hasEuAiSystemType](http://research.ibm.com/ontologies/aiont/hasEuAiS
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -51,7 +51,7 @@ URI: [nexus:hasEuAiSystemType](http://research.ibm.com/ontologies/aiont/hasEuAiS
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [nexus:hasEuAiSystemType](http://research.ibm.com/ontologies/aiont/hasEuAiS
 ```yaml
 name: hasEuAiSystemType
 description: The type of system as defined by the EU AI Act.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasEuAiSystemType
 domain_of:

--- a/docs/ontology/hasEuRiskCategory.md
+++ b/docs/ontology/hasEuRiskCategory.md
@@ -9,7 +9,7 @@ _The risk category of an AI system as defined by the EU AI Act._
 
 
 
-URI: [nexus:hasEuRiskCategory](http://research.ibm.com/ontologies/aiont/hasEuRiskCategory)
+URI: [nexus:hasEuRiskCategory](https://ibm.github.io/risk-atlas-nexus/ontology/hasEuRiskCategory)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:hasEuRiskCategory](http://research.ibm.com/ontologies/aiont/hasEuRis
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -51,7 +51,7 @@ URI: [nexus:hasEuRiskCategory](http://research.ibm.com/ontologies/aiont/hasEuRis
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [nexus:hasEuRiskCategory](http://research.ibm.com/ontologies/aiont/hasEuRis
 ```yaml
 name: hasEuRiskCategory
 description: The risk category of an AI system as defined by the EU AI Act.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasEuRiskCategory
 domain_of:

--- a/docs/ontology/hasEvaluation.md
+++ b/docs/ontology/hasEvaluation.md
@@ -23,8 +23,8 @@ URI: [dqv:hasQualityMeasurement](https://www.w3.org/TR/vocab-dqv/hasQualityMeasu
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [dqv:hasQualityMeasurement](https://www.w3.org/TR/vocab-dqv/hasQualityMeasu
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [dqv:hasQualityMeasurement](https://www.w3.org/TR/vocab-dqv/hasQualityMeasu
 ```yaml
 name: hasEvaluation
 description: A relationship indicating that an entity has an AI evaluation result.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: dqv:hasQualityMeasurement
 alias: hasEvaluation

--- a/docs/ontology/hasInputModality.md
+++ b/docs/ontology/hasInputModality.md
@@ -9,7 +9,7 @@ _A relationship indicating the input modalities supported by an AI component. Ex
 
 
 
-URI: [nexus:hasInputModality](http://research.ibm.com/ontologies/aiont/hasInputModality)
+URI: [nexus:hasInputModality](https://ibm.github.io/risk-atlas-nexus/ontology/hasInputModality)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasInputModality](http://research.ibm.com/ontologies/aiont/hasInputM
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:hasInputModality](http://research.ibm.com/ontologies/aiont/hasInputM
 name: hasInputModality
 description: A relationship indicating the input modalities supported by an AI component.
   Examples include text, image, video.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasInputModality
 domain_of:

--- a/docs/ontology/hasLicense.md
+++ b/docs/ontology/hasLicense.md
@@ -23,16 +23,16 @@ URI: [airo:hasLicense](https://w3id.org/airo#hasLicense)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
 
 
 
@@ -59,7 +59,7 @@ URI: [airo:hasLicense](https://w3id.org/airo#hasLicense)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -80,7 +80,7 @@ URI: [airo:hasLicense](https://w3id.org/airo#hasLicense)
 ```yaml
 name: hasLicense
 description: Indicates licenses associated with a resource
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: airo:hasLicense
 alias: hasLicense

--- a/docs/ontology/hasModelCard.md
+++ b/docs/ontology/hasModelCard.md
@@ -9,7 +9,7 @@ _A relationship to model card references._
 
 
 
-URI: [nexus:hasModelCard](http://research.ibm.com/ontologies/aiont/hasModelCard)
+URI: [nexus:hasModelCard](https://ibm.github.io/risk-atlas-nexus/ontology/hasModelCard)
 
 
 
@@ -23,11 +23,11 @@ URI: [nexus:hasModelCard](http://research.ibm.com/ontologies/aiont/hasModelCard)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -56,7 +56,7 @@ URI: [nexus:hasModelCard](http://research.ibm.com/ontologies/aiont/hasModelCard)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -77,7 +77,7 @@ URI: [nexus:hasModelCard](http://research.ibm.com/ontologies/aiont/hasModelCard)
 ```yaml
 name: hasModelCard
 description: A relationship to model card references.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasModelCard
 domain_of:

--- a/docs/ontology/hasOutputModality.md
+++ b/docs/ontology/hasOutputModality.md
@@ -9,7 +9,7 @@ _A relationship indicating the output modalities supported by an AI component. E
 
 
 
-URI: [nexus:hasOutputModality](http://research.ibm.com/ontologies/aiont/hasOutputModality)
+URI: [nexus:hasOutputModality](https://ibm.github.io/risk-atlas-nexus/ontology/hasOutputModality)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasOutputModality](http://research.ibm.com/ontologies/aiont/hasOutpu
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:hasOutputModality](http://research.ibm.com/ontologies/aiont/hasOutpu
 name: hasOutputModality
 description: A relationship indicating the output modalities supported by an AI component.
   Examples include text, image, video.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasOutputModality
 domain_of:

--- a/docs/ontology/hasPart.md
+++ b/docs/ontology/hasPart.md
@@ -52,7 +52,7 @@ URI: [schema:hasPart](http://schema.org/hasPart)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [schema:hasPart](http://schema.org/hasPart)
 ```yaml
 name: hasPart
 description: A relationship where an entity has another entity
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:hasPart
 alias: hasPart

--- a/docs/ontology/hasRelatedAction.md
+++ b/docs/ontology/hasRelatedAction.md
@@ -9,7 +9,7 @@ _A relationship where an entity relates to an action_
 
 
 
-URI: [nexus:hasRelatedAction](http://research.ibm.com/ontologies/aiont/hasRelatedAction)
+URI: [nexus:hasRelatedAction](https://ibm.github.io/risk-atlas-nexus/ontology/hasRelatedAction)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:hasRelatedAction](http://research.ibm.com/ontologies/aiont/hasRelate
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:hasRelatedAction](http://research.ibm.com/ontologies/aiont/hasRelate
 ```yaml
 name: hasRelatedAction
 description: A relationship where an entity relates to an action
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasRelatedAction
 domain_of:

--- a/docs/ontology/hasRelatedRisk.md
+++ b/docs/ontology/hasRelatedRisk.md
@@ -9,7 +9,7 @@ _A relationship where an entity relates to a risk_
 
 
 
-URI: [nexus:hasRelatedRisk](http://research.ibm.com/ontologies/aiont/hasRelatedRisk)
+URI: [nexus:hasRelatedRisk](https://ibm.github.io/risk-atlas-nexus/ontology/hasRelatedRisk)
 
 
 
@@ -23,10 +23,10 @@ URI: [nexus:hasRelatedRisk](http://research.ibm.com/ontologies/aiont/hasRelatedR
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Action](Action.md) | Action to remediate a risk |  no  |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
 
 
 
@@ -55,7 +55,7 @@ URI: [nexus:hasRelatedRisk](http://research.ibm.com/ontologies/aiont/hasRelatedR
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ URI: [nexus:hasRelatedRisk](http://research.ibm.com/ontologies/aiont/hasRelatedR
 ```yaml
 name: hasRelatedRisk
 description: A relationship where an entity relates to a risk
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: hasRelatedRisk
 domain_of:

--- a/docs/ontology/hasRiskControl.md
+++ b/docs/ontology/hasRiskControl.md
@@ -23,8 +23,8 @@ URI: [airo:hasRiskControl](https://w3id.org/airo#hasRiskControl)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [airo:hasRiskControl](https://w3id.org/airo#hasRiskControl)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [airo:hasRiskControl](https://w3id.org/airo#hasRiskControl)
 name: hasRiskControl
 description: Indicates the control measures associated with a system or component
   to modify risks.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: airo:hasRiskControl
 alias: hasRiskControl

--- a/docs/ontology/hasTrainingData.md
+++ b/docs/ontology/hasTrainingData.md
@@ -52,7 +52,7 @@ URI: [airo:hasTrainingData](https://w3id.org/airo#hasTrainingData)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [airo:hasTrainingData](https://w3id.org/airo#hasTrainingData)
 ```yaml
 name: hasTrainingData
 description: A relationship indicating the datasets an AI model was trained on.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: airo:hasTrainingData
 alias: hasTrainingData

--- a/docs/ontology/hasUnitxtCard.md
+++ b/docs/ontology/hasUnitxtCard.md
@@ -24,8 +24,8 @@ URI: [schema:url](http://schema.org/url)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
 
 
 
@@ -52,7 +52,7 @@ URI: [schema:url](http://schema.org/url)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [schema:url](http://schema.org/url)
 ```yaml
 name: hasUnitxtCard
 description: A relationship to a Unitxt card defining the risk evaluation
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:url
 alias: hasUnitxtCard

--- a/docs/ontology/id.md
+++ b/docs/ontology/id.md
@@ -23,34 +23,34 @@ URI: [schema:identifier](http://schema.org/identifier)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -79,7 +79,7 @@ URI: [schema:identifier](http://schema.org/identifier)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -101,7 +101,7 @@ URI: [schema:identifier](http://schema.org/identifier)
 name: id
 description: A unique identifier to this instance of the model element. Example identifiers
   include UUID, URI, URN, etc.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:identifier
 identifier: true

--- a/docs/ontology/index.md
+++ b/docs/ontology/index.md
@@ -2,7 +2,7 @@
 
 An ontology describing AI systems and their risks
 
-URI: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+URI: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 Name: ai-risk-ontology
 

--- a/docs/ontology/isComposedOf.md
+++ b/docs/ontology/isComposedOf.md
@@ -9,7 +9,7 @@ _Relationship indicating the some entity is composed of other entities (includin
 
 
 
-URI: [nexus:isComposedOf](http://research.ibm.com/ontologies/aiont/isComposedOf)
+URI: [nexus:isComposedOf](https://ibm.github.io/risk-atlas-nexus/ontology/isComposedOf)
 
 
 
@@ -43,7 +43,7 @@ URI: [nexus:isComposedOf](http://research.ibm.com/ontologies/aiont/isComposedOf)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -65,7 +65,7 @@ URI: [nexus:isComposedOf](http://research.ibm.com/ontologies/aiont/isComposedOf)
 name: isComposedOf
 description: Relationship indicating the some entity is composed of other entities
   (including some of the same type).
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: isComposedOf
 range: string

--- a/docs/ontology/isDefinedByTaxonomy.md
+++ b/docs/ontology/isDefinedByTaxonomy.md
@@ -23,8 +23,8 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 | [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 | [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
 | [Action](Action.md) | Action to remediate a risk |  no  |
 
@@ -53,7 +53,7 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 ```yaml
 name: isDefinedByTaxonomy
 description: A relationship where a risk or a risk group is defined by a risk taxonomy
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:isPartOf
 alias: isDefinedByTaxonomy

--- a/docs/ontology/isDeployedBy.md
+++ b/docs/ontology/isDeployedBy.md
@@ -9,7 +9,7 @@ _A relationship indicating that an entity has been deployed by an organization._
 
 
 
-URI: [nexus:isDeployedBy](http://research.ibm.com/ontologies/aiont/isDeployedBy)
+URI: [nexus:isDeployedBy](https://ibm.github.io/risk-atlas-nexus/ontology/isDeployedBy)
 
 
 
@@ -41,7 +41,7 @@ URI: [nexus:isDeployedBy](http://research.ibm.com/ontologies/aiont/isDeployedBy)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -62,7 +62,7 @@ URI: [nexus:isDeployedBy](http://research.ibm.com/ontologies/aiont/isDeployedBy)
 ```yaml
 name: isDeployedBy
 description: A relationship indicating that an entity has been deployed by an organization.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: isDeployedBy
 range: Organization

--- a/docs/ontology/isDetectedBy.md
+++ b/docs/ontology/isDetectedBy.md
@@ -9,7 +9,7 @@ _A relationship where a risk, risk source, consequence, or impact is detected by
 
 
 
-URI: [nexus:isDetectedBy](http://research.ibm.com/ontologies/aiont/isDetectedBy)
+URI: [nexus:isDetectedBy](https://ibm.github.io/risk-atlas-nexus/ontology/isDetectedBy)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:isDetectedBy](http://research.ibm.com/ontologies/aiont/isDetectedBy)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 | [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 | [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
 
 
@@ -54,7 +54,7 @@ URI: [nexus:isDetectedBy](http://research.ibm.com/ontologies/aiont/isDetectedBy)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ URI: [nexus:isDetectedBy](http://research.ibm.com/ontologies/aiont/isDetectedBy)
 name: isDetectedBy
 description: A relationship where a risk, risk source, consequence, or impact is detected
   by a risk control.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: isDetectedBy
 domain_of:

--- a/docs/ontology/isDistributedBy.md
+++ b/docs/ontology/isDistributedBy.md
@@ -9,7 +9,7 @@ _A relationship indicating that an entity has been distributed by an organizatio
 
 
 
-URI: [nexus:isDistributedBy](http://research.ibm.com/ontologies/aiont/isDistributedBy)
+URI: [nexus:isDistributedBy](https://ibm.github.io/risk-atlas-nexus/ontology/isDistributedBy)
 
 
 
@@ -41,7 +41,7 @@ URI: [nexus:isDistributedBy](http://research.ibm.com/ontologies/aiont/isDistribu
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -62,7 +62,7 @@ URI: [nexus:isDistributedBy](http://research.ibm.com/ontologies/aiont/isDistribu
 ```yaml
 name: isDistributedBy
 description: A relationship indicating that an entity has been distributed by an organization.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: isDistributedBy
 range: Organization

--- a/docs/ontology/isImportedBy.md
+++ b/docs/ontology/isImportedBy.md
@@ -9,7 +9,7 @@ _A relationship indicating that an entity has been imported by an organization._
 
 
 
-URI: [nexus:isImportedBy](http://research.ibm.com/ontologies/aiont/isImportedBy)
+URI: [nexus:isImportedBy](https://ibm.github.io/risk-atlas-nexus/ontology/isImportedBy)
 
 
 
@@ -41,7 +41,7 @@ URI: [nexus:isImportedBy](http://research.ibm.com/ontologies/aiont/isImportedBy)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -62,7 +62,7 @@ URI: [nexus:isImportedBy](http://research.ibm.com/ontologies/aiont/isImportedBy)
 ```yaml
 name: isImportedBy
 description: A relationship indicating that an entity has been imported by an organization.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: isImportedBy
 range: Organization

--- a/docs/ontology/isPartOf.md
+++ b/docs/ontology/isPartOf.md
@@ -51,7 +51,7 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 ```yaml
 name: isPartOf
 description: A relationship where an entity is part of another entity
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:isPartOf
 alias: isPartOf

--- a/docs/ontology/isProvidedBy.md
+++ b/docs/ontology/isProvidedBy.md
@@ -23,11 +23,11 @@ URI: [airo:isProvidedBy](https://w3id.org/airo#isProvidedBy)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  yes  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  yes  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -54,7 +54,7 @@ URI: [airo:isProvidedBy](https://w3id.org/airo#isProvidedBy)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ URI: [airo:isProvidedBy](https://w3id.org/airo#isProvidedBy)
 name: isProvidedBy
 description: A relationship indicating the AI model has been provided by an AI model
   provider.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: airo:isProvidedBy
 alias: isProvidedBy

--- a/docs/ontology/isResultOf.md
+++ b/docs/ontology/isResultOf.md
@@ -50,7 +50,7 @@ URI: [dqv:isMeasurementOf](https://www.w3.org/TR/vocab-dqv/isMeasurementOf)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [dqv:isMeasurementOf](https://www.w3.org/TR/vocab-dqv/isMeasurementOf)
 ```yaml
 name: isResultOf
 description: A relationship indicating that an entity is the result of an AI evaluation.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: dqv:isMeasurementOf
 alias: isResultOf

--- a/docs/ontology/licenses.md
+++ b/docs/ontology/licenses.md
@@ -9,7 +9,7 @@ _A list of licenses_
 
 
 
-URI: [nexus:licenses](http://research.ibm.com/ontologies/aiont/licenses)
+URI: [nexus:licenses](https://ibm.github.io/risk-atlas-nexus/ontology/licenses)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:licenses](http://research.ibm.com/ontologies/aiont/licenses)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:licenses](http://research.ibm.com/ontologies/aiont/licenses)
 ```yaml
 name: licenses
 description: A list of licenses
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: licenses
 owner: Container

--- a/docs/ontology/modalities.md
+++ b/docs/ontology/modalities.md
@@ -9,7 +9,7 @@ _A list of AI modalities_
 
 
 
-URI: [nexus:modalities](http://research.ibm.com/ontologies/aiont/modalities)
+URI: [nexus:modalities](https://ibm.github.io/risk-atlas-nexus/ontology/modalities)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:modalities](http://research.ibm.com/ontologies/aiont/modalities)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:modalities](http://research.ibm.com/ontologies/aiont/modalities)
 ```yaml
 name: modalities
 description: A list of AI modalities
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: modalities
 owner: Container

--- a/docs/ontology/name.md
+++ b/docs/ontology/name.md
@@ -23,34 +23,34 @@ URI: [schema:name](http://schema.org/name)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -77,7 +77,7 @@ URI: [schema:name](http://schema.org/name)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -98,7 +98,7 @@ URI: [schema:name](http://schema.org/name)
 ```yaml
 name: name
 description: A text name of this instance.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:name
 alias: name

--- a/docs/ontology/narrowMatch.md
+++ b/docs/ontology/narrowMatch.md
@@ -53,7 +53,7 @@ URI: [skos:narrowMatch](http://www.w3.org/2004/02/skos/core/narrowMatch)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -76,7 +76,7 @@ name: narrowMatch
 description: The property is used to state a hierarchical mapping link between two
   concepts, indicating that the concept linked to, is a narrower concept than the
   originating concept.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: skos:narrowMatch
 alias: narrowMatch

--- a/docs/ontology/numParameters.md
+++ b/docs/ontology/numParameters.md
@@ -9,7 +9,7 @@ _A property indicating the number of parameters in a LLM._
 
 
 
-URI: [nexus:numParameters](http://research.ibm.com/ontologies/aiont/numParameters)
+URI: [nexus:numParameters](https://ibm.github.io/risk-atlas-nexus/ontology/numParameters)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:numParameters](http://research.ibm.com/ontologies/aiont/numParameter
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:numParameters](http://research.ibm.com/ontologies/aiont/numParameter
 ```yaml
 name: numParameters
 description: A property indicating the number of parameters in a LLM.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: numParameters
 domain_of:

--- a/docs/ontology/numTrainingTokens.md
+++ b/docs/ontology/numTrainingTokens.md
@@ -9,7 +9,7 @@ _The number of tokens a AI model was trained on._
 
 
 
-URI: [nexus:numTrainingTokens](http://research.ibm.com/ontologies/aiont/numTrainingTokens)
+URI: [nexus:numTrainingTokens](https://ibm.github.io/risk-atlas-nexus/ontology/numTrainingTokens)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:numTrainingTokens](http://research.ibm.com/ontologies/aiont/numTrain
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:numTrainingTokens](http://research.ibm.com/ontologies/aiont/numTrain
 ```yaml
 name: numTrainingTokens
 description: The number of tokens a AI model was trained on.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: numTrainingTokens
 domain_of:

--- a/docs/ontology/organizations.md
+++ b/docs/ontology/organizations.md
@@ -9,7 +9,7 @@ _A list of organizations_
 
 
 
-URI: [nexus:organizations](http://research.ibm.com/ontologies/aiont/organizations)
+URI: [nexus:organizations](https://ibm.github.io/risk-atlas-nexus/ontology/organizations)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:organizations](http://research.ibm.com/ontologies/aiont/organization
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:organizations](http://research.ibm.com/ontologies/aiont/organization
 ```yaml
 name: organizations
 description: A list of organizations
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: organizations
 owner: Container

--- a/docs/ontology/performsTask.md
+++ b/docs/ontology/performsTask.md
@@ -9,7 +9,7 @@ _relationship indicating the AI tasks an AI model can perform._
 
 
 
-URI: [nexus:performsTask](http://research.ibm.com/ontologies/aiont/performsTask)
+URI: [nexus:performsTask](https://ibm.github.io/risk-atlas-nexus/ontology/performsTask)
 
 
 
@@ -23,11 +23,11 @@ URI: [nexus:performsTask](http://research.ibm.com/ontologies/aiont/performsTask)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -56,7 +56,7 @@ URI: [nexus:performsTask](http://research.ibm.com/ontologies/aiont/performsTask)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -77,7 +77,7 @@ URI: [nexus:performsTask](http://research.ibm.com/ontologies/aiont/performsTask)
 ```yaml
 name: performsTask
 description: relationship indicating the AI tasks an AI model can perform.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: performsTask
 domain_of:

--- a/docs/ontology/phase.md
+++ b/docs/ontology/phase.md
@@ -9,7 +9,7 @@ _Annotation whether an AI risk shows specifically during the training-tuning or 
 
 
 
-URI: [nexus:phase](http://research.ibm.com/ontologies/aiont/phase)
+URI: [nexus:phase](https://ibm.github.io/risk-atlas-nexus/ontology/phase)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:phase](http://research.ibm.com/ontologies/aiont/phase)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [nexus:phase](http://research.ibm.com/ontologies/aiont/phase)
 name: phase
 description: Annotation whether an AI risk shows specifically during the training-tuning
   or inference phase.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: phase
 owner: Risk

--- a/docs/ontology/power_consumption_w.md
+++ b/docs/ontology/power_consumption_w.md
@@ -9,7 +9,7 @@ _power consumption in Watts_
 
 
 
-URI: [nexus:power_consumption_w](http://research.ibm.com/ontologies/aiont/power_consumption_w)
+URI: [nexus:power_consumption_w](https://ibm.github.io/risk-atlas-nexus/ontology/power_consumption_w)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:power_consumption_w](http://research.ibm.com/ontologies/aiont/power_
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 | [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [nexus:power_consumption_w](http://research.ibm.com/ontologies/aiont/power_
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:power_consumption_w](http://research.ibm.com/ontologies/aiont/power_
 ```yaml
 name: power_consumption_w
 description: power consumption in Watts
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: power_consumption_w
 domain_of:

--- a/docs/ontology/producer.md
+++ b/docs/ontology/producer.md
@@ -9,7 +9,7 @@ _A relationship to the Organization instance which produces this instance._
 
 
 
-URI: [nexus:producer](http://research.ibm.com/ontologies/aiont/producer)
+URI: [nexus:producer](https://ibm.github.io/risk-atlas-nexus/ontology/producer)
 
 
 
@@ -23,11 +23,11 @@ URI: [nexus:producer](http://research.ibm.com/ontologies/aiont/producer)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 
 
 
@@ -54,7 +54,7 @@ URI: [nexus:producer](http://research.ibm.com/ontologies/aiont/producer)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [nexus:producer](http://research.ibm.com/ontologies/aiont/producer)
 ```yaml
 name: producer
 description: A relationship to the Organization instance which produces this instance.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: producer
 domain_of:

--- a/docs/ontology/provider.md
+++ b/docs/ontology/provider.md
@@ -50,7 +50,7 @@ URI: [schema:provider](http://schema.org/provider)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [schema:provider](http://schema.org/provider)
 ```yaml
 name: provider
 description: A relationship to the Organization instance that provides this instance.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:provider
 alias: provider

--- a/docs/ontology/relatedMatch.md
+++ b/docs/ontology/relatedMatch.md
@@ -53,7 +53,7 @@ URI: [skos:relatedMatch](http://www.w3.org/2004/02/skos/core/relatedMatch)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -75,7 +75,7 @@ URI: [skos:relatedMatch](http://www.w3.org/2004/02/skos/core/relatedMatch)
 name: relatedMatch
 description: The property skos:relatedMatch is used to state an associative mapping
   link between two concepts.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: skos:relatedMatch
 alias: relatedMatch

--- a/docs/ontology/riskcontrols.md
+++ b/docs/ontology/riskcontrols.md
@@ -9,7 +9,7 @@ _A list of AI risk controls_
 
 
 
-URI: [nexus:riskcontrols](http://research.ibm.com/ontologies/aiont/riskcontrols)
+URI: [nexus:riskcontrols](https://ibm.github.io/risk-atlas-nexus/ontology/riskcontrols)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:riskcontrols](http://research.ibm.com/ontologies/aiont/riskcontrols)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:riskcontrols](http://research.ibm.com/ontologies/aiont/riskcontrols)
 ```yaml
 name: riskcontrols
 description: A list of AI risk controls
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: riskcontrols
 owner: Container

--- a/docs/ontology/riskgroups.md
+++ b/docs/ontology/riskgroups.md
@@ -9,7 +9,7 @@ _A list of AI risk groups_
 
 
 
-URI: [nexus:riskgroups](http://research.ibm.com/ontologies/aiont/riskgroups)
+URI: [nexus:riskgroups](https://ibm.github.io/risk-atlas-nexus/ontology/riskgroups)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:riskgroups](http://research.ibm.com/ontologies/aiont/riskgroups)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:riskgroups](http://research.ibm.com/ontologies/aiont/riskgroups)
 ```yaml
 name: riskgroups
 description: A list of AI risk groups
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: riskgroups
 owner: Container

--- a/docs/ontology/risks.md
+++ b/docs/ontology/risks.md
@@ -9,7 +9,7 @@ _A list of AI risks_
 
 
 
-URI: [nexus:risks](http://research.ibm.com/ontologies/aiont/risks)
+URI: [nexus:risks](https://ibm.github.io/risk-atlas-nexus/ontology/risks)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:risks](http://research.ibm.com/ontologies/aiont/risks)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:risks](http://research.ibm.com/ontologies/aiont/risks)
 ```yaml
 name: risks
 description: A list of AI risks
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: risks
 owner: Container

--- a/docs/ontology/supported_languages.md
+++ b/docs/ontology/supported_languages.md
@@ -9,7 +9,7 @@ _A list of languages, expressed as ISO two letter codes. For example, 'jp, fr, e
 
 
 
-URI: [nexus:supported_languages](http://research.ibm.com/ontologies/aiont/supported_languages)
+URI: [nexus:supported_languages](https://ibm.github.io/risk-atlas-nexus/ontology/supported_languages)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:supported_languages](http://research.ibm.com/ontologies/aiont/suppor
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:supported_languages](http://research.ibm.com/ontologies/aiont/suppor
 name: supported_languages
 description: A list of languages, expressed as ISO two letter codes. For example,
   'jp, fr, en, de'
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: supported_languages
 domain_of:

--- a/docs/ontology/tag.md
+++ b/docs/ontology/tag.md
@@ -9,7 +9,7 @@ _A shost version of the name_
 
 
 
-URI: [nexus:tag](http://research.ibm.com/ontologies/aiont/tag)
+URI: [nexus:tag](https://ibm.github.io/risk-atlas-nexus/ontology/tag)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:tag](http://research.ibm.com/ontologies/aiont/tag)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [nexus:tag](http://research.ibm.com/ontologies/aiont/tag)
 ```yaml
 name: tag
 description: A shost version of the name
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: tag
 owner: Risk

--- a/docs/ontology/taxonomies.md
+++ b/docs/ontology/taxonomies.md
@@ -9,7 +9,7 @@ _A list of AI risk taxonomies_
 
 
 
-URI: [nexus:taxonomies](http://research.ibm.com/ontologies/aiont/taxonomies)
+URI: [nexus:taxonomies](https://ibm.github.io/risk-atlas-nexus/ontology/taxonomies)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:taxonomies](http://research.ibm.com/ontologies/aiont/taxonomies)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:taxonomies](http://research.ibm.com/ontologies/aiont/taxonomies)
 ```yaml
 name: taxonomies
 description: A list of AI risk taxonomies
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: taxonomies
 owner: Container

--- a/docs/ontology/text.md
+++ b/docs/ontology/text.md
@@ -9,7 +9,7 @@ _The question itself_
 
 
 
-URI: [nexus:text](http://research.ibm.com/ontologies/aiont/text)
+URI: [nexus:text](https://ibm.github.io/risk-atlas-nexus/ontology/text)
 
 
 
@@ -52,7 +52,7 @@ URI: [nexus:text](http://research.ibm.com/ontologies/aiont/text)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -73,7 +73,7 @@ URI: [nexus:text](http://research.ibm.com/ontologies/aiont/text)
 ```yaml
 name: text
 description: The question itself
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: text
 owner: Question

--- a/docs/ontology/training_data_preprocessing.md
+++ b/docs/ontology/training_data_preprocessing.md
@@ -9,7 +9,7 @@ _relationship indicating data preprocessing steps performed on training data set
 
 
 
-URI: [nexus:training_data_preprocessing](http://research.ibm.com/ontologies/aiont/training_data_preprocessing)
+URI: [nexus:training_data_preprocessing](https://ibm.github.io/risk-atlas-nexus/ontology/training_data_preprocessing)
 
 
 
@@ -43,7 +43,7 @@ URI: [nexus:training_data_preprocessing](http://research.ibm.com/ontologies/aion
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -65,7 +65,7 @@ URI: [nexus:training_data_preprocessing](http://research.ibm.com/ontologies/aion
 name: training_data_preprocessing
 description: relationship indicating data preprocessing steps performed on training
   data sets to ensure high quality training data.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: training_data_preprocessing
 range: DataPreprocessing

--- a/docs/ontology/type.md
+++ b/docs/ontology/type.md
@@ -9,7 +9,7 @@ _Annotation whether an AI risk occurs at input or output or is non-technical._
 
 
 
-URI: [nexus:type](http://research.ibm.com/ontologies/aiont/type)
+URI: [nexus:type](https://ibm.github.io/risk-atlas-nexus/ontology/type)
 
 
 
@@ -50,7 +50,7 @@ URI: [nexus:type](http://research.ibm.com/ontologies/aiont/type)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -71,7 +71,7 @@ URI: [nexus:type](http://research.ibm.com/ontologies/aiont/type)
 ```yaml
 name: type
 description: Annotation whether an AI risk occurs at input or output or is non-technical.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: type
 owner: Risk

--- a/docs/ontology/url.md
+++ b/docs/ontology/url.md
@@ -23,34 +23,34 @@ URI: [schema:url](http://schema.org/url)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 | [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 
 
 
@@ -77,7 +77,7 @@ URI: [schema:url](http://schema.org/url)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -98,7 +98,7 @@ URI: [schema:url](http://schema.org/url)
 ```yaml
 name: url
 description: An optional URL associated with this instance.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:url
 alias: url

--- a/docs/ontology/validated_by.md
+++ b/docs/ontology/validated_by.md
@@ -9,7 +9,7 @@ _A relationship indicating the model validation steps after AI model training._
 
 
 
-URI: [nexus:validated_by](http://research.ibm.com/ontologies/aiont/validated_by)
+URI: [nexus:validated_by](https://ibm.github.io/risk-atlas-nexus/ontology/validated_by)
 
 
 
@@ -43,7 +43,7 @@ URI: [nexus:validated_by](http://research.ibm.com/ontologies/aiont/validated_by)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -64,7 +64,7 @@ URI: [nexus:validated_by](http://research.ibm.com/ontologies/aiont/validated_by)
 ```yaml
 name: validated_by
 description: A relationship indicating the model validation steps after AI model training.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: validated_by
 range: AiModelValidation

--- a/docs/ontology/value.md
+++ b/docs/ontology/value.md
@@ -9,7 +9,7 @@ _Some numeric or string value_
 
 
 
-URI: [nexus:value](http://research.ibm.com/ontologies/aiont/value)
+URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 
 
@@ -23,8 +23,8 @@ URI: [nexus:value](http://research.ibm.com/ontologies/aiont/value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 | [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
 
 
 
@@ -53,7 +53,7 @@ URI: [nexus:value](http://research.ibm.com/ontologies/aiont/value)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -74,7 +74,7 @@ URI: [nexus:value](http://research.ibm.com/ontologies/aiont/value)
 ```yaml
 name: value
 description: Some numeric or string value
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 alias: value
 domain_of:

--- a/docs/ontology/version.md
+++ b/docs/ontology/version.md
@@ -23,8 +23,8 @@ URI: [schema:version](http://schema.org/version)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 | [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
 
 
 
@@ -51,7 +51,7 @@ URI: [schema:version](http://schema.org/version)
 ### Schema Source
 
 
-* from schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 
 
 
@@ -72,7 +72,7 @@ URI: [schema:version](http://schema.org/version)
 ```yaml
 name: version
 description: The version of the entity embodied by a specified resource.
-from_schema: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
 slot_uri: schema:version
 alias: version

--- a/graph_export/owl/ai-risk-ontology_schema.ttl
+++ b/graph_export/owl/ai-risk-ontology_schema.ttl
@@ -1,7 +1,7 @@
 @prefix airo: <https://w3id.org/airo#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix linkml: <https://w3id.org/linkml/> .
-@prefix nexus: <http://research.ibm.com/ontologies/aiont/> .
+@prefix nexus: <https://ibm.github.io/risk-atlas-nexus/ontology/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix pav: <http://purl.org/pav/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -28,41 +28,65 @@ nexus:AiOffice a owl:Class ;
     rdfs:label "AiOffice" ;
     rdfs:subClassOf nexus:Organization ;
     skos:definition "The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office)" ;
-    skos:exactMatch <schema:Organization> ;
+    skos:exactMatch <http://schema.org/Organization> ;
     skos:inScheme nexus:eu_ai_act .
 
 nexus:Container a owl:Class ;
     rdfs:label "Container" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
-            owl:onProperty nexus:modalities ],
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModel ;
+            owl:onProperty nexus:aimodels ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:risks ],
+            owl:onProperty nexus:actions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:organizations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:datasets ],
+            owl:onProperty nexus:aimodelfamilies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:taxonomies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:modalities ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:licenses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
+            owl:onProperty nexus:aimodelfamilies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:risks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:datasets ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Action ;
             owl:onProperty nexus:actions ],
         [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
+            owl:onProperty nexus:organizations ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:riskgroups ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:risks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Modality ;
             owl:onProperty nexus:modalities ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
-            owl:onProperty nexus:aitasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:taxonomies ],
+            owl:allValuesFrom nexus:RiskGroup ;
+            owl:onProperty nexus:riskgroups ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:aimodels ],
@@ -70,66 +94,42 @@ nexus:Container a owl:Class ;
             owl:allValuesFrom nexus:AiEval ;
             owl:onProperty nexus:evaluations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
-            owl:onProperty nexus:aimodelfamilies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskGroup ;
-            owl:onProperty nexus:riskgroups ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:risks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aitasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:organizations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModel ;
-            owl:onProperty nexus:aimodels ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:evaluations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:documents ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
             owl:onProperty nexus:datasets ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:organizations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:taxonomies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:licenses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:actions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aimodelfamilies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskgroups ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:documents ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:licenses ] ;
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:documents ] ;
     skos:definition "An umbrella object that holds the ontology class instances" ;
     skos:inScheme nexus:ai-risk-ontology .
 
 nexus:Questionnaire a owl:Class ;
     rdfs:label "Questionnaire" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:composed_of ],
-        [ a owl:Restriction ;
             owl:allValuesFrom nexus:Question ;
             owl:onProperty nexus:composed_of ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:composed_of ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:composed_of ],
         nexus:AiEval ;
     skos:definition "A questionnaire groups questions" ;
@@ -174,14 +174,20 @@ nexus:validated_by a owl:ObjectProperty ;
 nexus:AiModel a owl:Class ;
     rdfs:label "AiModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:carbon_emitted ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:carbon_emitted ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasRiskControl ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:architecture ],
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEvalResult ;
-            owl:onProperty nexus:hasEvaluation ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -190,13 +196,28 @@ nexus:AiModel a owl:Class ;
             owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:hasEvaluation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:gpu_hours ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:gpu_hours ],
+            owl:allValuesFrom nexus:AiEvalResult ;
+            owl:onProperty nexus:hasEvaluation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:hasRiskControl ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:gpu_hours ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:float [ a rdfs:Datatype ;
@@ -204,32 +225,11 @@ nexus:AiModel a owl:Class ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:power_consumption_w ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEvaluation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:hasRiskControl ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:architecture ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:gpu_hours ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:carbon_emitted ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:power_consumption_w ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:carbon_emitted ],
+            owl:onProperty nexus:gpu_hours ],
         nexus:BaseAi ;
     skos:definition "A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclassed by model types (see LargeLanguageModel)." ;
     skos:inScheme nexus:ai_system .
@@ -243,28 +243,28 @@ nexus:AiModelValidation a owl:Class ;
 nexus:AiSystem a owl:Class ;
     rdfs:label "AiSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:BaseAi ;
             owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasEuAiSystemType ],
+            owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:AiSystemType ;
             owl:onProperty nexus:hasEuAiSystemType ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEuRiskCategory ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasEuRiskCategory ],
-        [ a owl:Restriction ;
             owl:allValuesFrom nexus:EuAiRiskCategory ;
             owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:BaseAi ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:isComposedOf ],
         nexus:BaseAi ;
     skos:definition "A compound AI System composed of one or more AI capablities. ChatGPT is an example of an AI system which deploys multiple GPT AI models." ;
@@ -280,107 +280,107 @@ nexus:DataPreprocessing a owl:Class ;
 nexus:Fact a owl:Class ;
     rdfs:label "Fact" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:evidence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:evidence ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty nexus:value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:value ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:evidence ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:evidence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:value ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:evidence ] ;
+            owl:onProperty nexus:value ] ;
     skos:definition "A fact about something, for example the result of a measurement. In addition to the value, evidence is provided." ;
-    skos:exactMatch <schema:Statement> ;
+    skos:exactMatch <http://schema.org/Statement> ;
     skos:inScheme nexus:common .
 
 nexus:LargeLanguageModel a owl:Class ;
     rdfs:label "LargeLanguageModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasInputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:supported_languages ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:fine_tuning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasTrainingData ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:contextWindowSize ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:supported_languages ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:numTrainingTokens ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:fine_tuning ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:numTrainingTokens ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:fine_tuning ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasOutputModality ],
+            owl:onProperty nexus:contextWindowSize ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
-            owl:onProperty nexus:hasInputModality ],
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:numTrainingTokens ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:numParameters ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:numParameters ],
+            owl:allValuesFrom nexus:Modality ;
+            owl:onProperty nexus:hasOutputModality ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:LargeLanguageModelFamily ;
             owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasOutputModality ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:numTrainingTokens ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:numParameters ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:supported_languages ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Dataset ;
             owl:onProperty nexus:hasTrainingData ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty nexus:contextWindowSize ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Modality ;
+            owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:supported_languages ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasTrainingData ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:numTrainingTokens ],
         nexus:AiModel ;
     skos:altLabel "LLM" ;
     skos:definition "A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture." ;
@@ -404,10 +404,10 @@ nexus:Question a owl:Class ;
 nexus:AiEvalResult a owl:Class ;
     rdfs:label "AiEvalResult" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isResultOf ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom nexus:AiEval ;
             owl:onProperty nexus:isResultOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -432,43 +432,43 @@ nexus:AiProvider a owl:Class ;
     skos:exactMatch airo:AIProvider ;
     skos:inScheme nexus:ai_system .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI> a owl:Class ;
     rdfs:label "GPAI" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI_OS> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI_OS> a owl:Class ;
     rdfs:label "GPAI_OS" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#HIGH_RISK> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#HIGH_RISK> a owl:Class ;
     rdfs:label "HIGH_RISK" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#MILITARY_SECURITY> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#MILITARY_SECURITY> a owl:Class ;
     rdfs:label "MILITARY_SECURITY" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#PROHIBITED> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#PROHIBITED> a owl:Class ;
     rdfs:label "PROHIBITED" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/AiSystemType#SCIENTIFIC_RD> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#SCIENTIFIC_RD> a owl:Class ;
     rdfs:label "SCIENTIFIC_RD" ;
     rdfs:subClassOf nexus:AiSystemType .
 
-<http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#HIGH> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#HIGH> a owl:Class ;
     rdfs:label "HIGH" ;
     rdfs:subClassOf nexus:EuAiRiskCategory .
 
-<http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#LIMITED> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#LIMITED> a owl:Class ;
     rdfs:label "LIMITED" ;
     rdfs:subClassOf nexus:EuAiRiskCategory .
 
-<http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#MINIMAL> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#MINIMAL> a owl:Class ;
     rdfs:label "MINIMAL" ;
     rdfs:subClassOf nexus:EuAiRiskCategory .
 
-<http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#UNACCEPTABLE> a owl:Class ;
+<https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#UNACCEPTABLE> a owl:Class ;
     rdfs:label "UNACCEPTABLE" ;
     rdfs:subClassOf nexus:EuAiRiskCategory .
 
@@ -628,31 +628,31 @@ nexus:Action a owl:Class ;
     rdfs:label "Action" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:hasAiActorTask ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
             owl:onProperty nexus:hasRelatedRisk ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasAiActorTask ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasAiActorTask ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:hasRelatedRisk ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
         nexus:Entity ;
     skos:definition "Action to remediate a risk" ;
     skos:inScheme nexus:ai_risk .
@@ -668,49 +668,49 @@ nexus:BaseAi a owl:Class ;
     rdfs:label "BaseAi" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:performsTask ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasModelCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasModelCard ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:AiProvider ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:isProvidedBy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
             owl:onProperty nexus:producer ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:performsTask ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
-            owl:onProperty nexus:performsTask ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:Organization ;
             owl:onProperty nexus:producer ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasModelCard ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:performsTask ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:producer ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
+            owl:onProperty nexus:isProvidedBy ],
         nexus:Entity ;
     skos:definition "Any type of AI, be it a LLM, RL agent, SVM, etc." ;
     skos:inScheme nexus:ai_system .
@@ -952,32 +952,32 @@ nexus:relatedMatch a owl:ObjectProperty ;
 nexus:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:provider ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
+            owl:onProperty nexus:provider ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:provider ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:provider ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:provider ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:provider ],
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
         nexus:Entity ;
     skos:definition "A body of structured information describing some topic(s) of interest." ;
-    skos:exactMatch <schema:Dataset> ;
+    skos:exactMatch <http://schema.org/Dataset> ;
     skos:inScheme nexus:common .
 
 nexus:Modality a owl:Class ;
@@ -990,10 +990,10 @@ nexus:Modality a owl:Class ;
 nexus:RiskConcept a owl:Class ;
     rdfs:label "RiskConcept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:isDetectedBy ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:RiskControl ;
             owl:onProperty nexus:isDetectedBy ],
         nexus:Entity ;
     skos:definition "An umbrella term for refering to risk, risk source, consequence and impact." ;
@@ -1003,19 +1003,19 @@ nexus:RiskConcept a owl:Class ;
 nexus:RiskControl a owl:Class ;
     rdfs:label "RiskControl" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskConcept ;
             owl:onProperty nexus:detectsRiskConcept ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         nexus:Entity ;
     skos:definition "A measure that maintains and/or modifies risk (and risk concepts)" ;
@@ -1033,76 +1033,82 @@ nexus:detectsRiskConcept a owl:ObjectProperty ;
 nexus:AiEval a owl:Class ;
     rdfs:label "AiEval" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedRisk ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
+            owl:onProperty nexus:hasUnitxtCard ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDataset ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:bestValue ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:hasDataset ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasUnitxtCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
             owl:onProperty nexus:hasUnitxtCard ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasUnitxtCard ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isComposedOf ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasUnitxtCard ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:hasRelatedRisk ],
+            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:AiEval ;
             owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:bestValue ],
+            owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
-            owl:onProperty nexus:hasDataset ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:bestValue ],
         nexus:Entity ;
     skos:definition "An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a question or a combination of such entities." ;
     skos:exactMatch <https://www.w3.org/TR/vocab-dqv/Metric> ;
     skos:inScheme nexus:ai_eval .
 
 nexus:EuAiRiskCategory a owl:Class ;
-    owl:unionOf ( <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#MINIMAL> <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#LIMITED> <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#HIGH> <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#UNACCEPTABLE> ) ;
-    linkml:permissible_values <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#HIGH>,
-        <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#LIMITED>,
-        <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#MINIMAL>,
-        <http://research.ibm.com/ontologies/aiont/EuAiRiskCategory#UNACCEPTABLE> .
+    owl:unionOf ( <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#MINIMAL> <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#LIMITED> <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#HIGH> <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#UNACCEPTABLE> ) ;
+    linkml:permissible_values <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#HIGH>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#LIMITED>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#MINIMAL>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#UNACCEPTABLE> .
 
 nexus:RiskTaxonomy a owl:Class ;
     rdfs:label "RiskTaxonomy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:version ],
@@ -1110,16 +1116,10 @@ nexus:RiskTaxonomy a owl:Class ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:version ],
+            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         nexus:Entity ;
     skos:definition "A taxonomy of AI system related risks" ;
@@ -1142,13 +1142,13 @@ nexus:version a owl:DatatypeProperty ;
     skos:inScheme nexus:common .
 
 nexus:AiSystemType a owl:Class ;
-    owl:unionOf ( <http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI> <http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI_OS> <http://research.ibm.com/ontologies/aiont/AiSystemType#PROHIBITED> <http://research.ibm.com/ontologies/aiont/AiSystemType#SCIENTIFIC_RD> <http://research.ibm.com/ontologies/aiont/AiSystemType#MILITARY_SECURITY> <http://research.ibm.com/ontologies/aiont/AiSystemType#HIGH_RISK> ) ;
-    linkml:permissible_values <http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI>,
-        <http://research.ibm.com/ontologies/aiont/AiSystemType#GPAI_OS>,
-        <http://research.ibm.com/ontologies/aiont/AiSystemType#HIGH_RISK>,
-        <http://research.ibm.com/ontologies/aiont/AiSystemType#MILITARY_SECURITY>,
-        <http://research.ibm.com/ontologies/aiont/AiSystemType#PROHIBITED>,
-        <http://research.ibm.com/ontologies/aiont/AiSystemType#SCIENTIFIC_RD> .
+    owl:unionOf ( <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI_OS> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#PROHIBITED> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#SCIENTIFIC_RD> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#MILITARY_SECURITY> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#HIGH_RISK> ) ;
+    linkml:permissible_values <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI_OS>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#HIGH_RISK>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#MILITARY_SECURITY>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#PROHIBITED>,
+        <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#SCIENTIFIC_RD> .
 
 nexus:Documentation a owl:Class ;
     rdfs:label "Documentation" ;
@@ -1160,13 +1160,13 @@ nexus:Documentation a owl:Class ;
 nexus:License a owl:Class ;
     rdfs:label "License" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:version ],
         nexus:Entity ;
     skos:definition "The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software." ;
@@ -1186,7 +1186,7 @@ nexus:Organization a owl:Class ;
             owl:onProperty nexus:grants_license ],
         nexus:Entity ;
     skos:definition "Any organizational entity such as a corporation, educational institution, consortium, government, etc." ;
-    skos:exactMatch <schema:Organization> ;
+    skos:exactMatch <http://schema.org/Organization> ;
     skos:inScheme nexus:common .
 
 nexus:hasDocumentation a owl:ObjectProperty ;
@@ -1215,61 +1215,61 @@ nexus:Any a owl:Class ;
 nexus:Entity a owl:Class ;
     rdfs:label "Entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateModified ],
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty nexus:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:dateModified ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
             owl:onProperty nexus:url ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:id ],
+            owl:onProperty nexus:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:url ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:dateModified ] ;
+            owl:onProperty nexus:name ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
-    skos:exactMatch <schema:Thing> ;
+    skos:exactMatch <http://schema.org/Thing> ;
     skos:inScheme nexus:common .
 
 nexus:RiskGroup a owl:Class ;
@@ -1279,46 +1279,46 @@ nexus:RiskGroup a owl:Class ;
             owl:onProperty nexus:narrowMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasPart ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:hasPart ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
+            owl:onProperty nexus:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:hasPart ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:closeMatch ],
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:broadMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasPart ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:closeMatch ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "A group of AI system related risks that are part of a risk taxonomy." ;
@@ -1327,71 +1327,17 @@ nexus:RiskGroup a owl:Class ;
 nexus:Risk a owl:Class ;
     rdfs:label "Risk" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:phase ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:phase ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
             owl:allValuesFrom nexus:Action ;
             owl:onProperty nexus:hasRelatedAction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedAction ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
+            owl:onProperty nexus:descriptor ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:descriptor ],
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:narrowMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
@@ -1400,28 +1346,7 @@ nexus:Risk a owl:Class ;
             owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:phase ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskConcept ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
+            owl:onProperty nexus:descriptor ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:exactMatch ],
@@ -1429,8 +1354,83 @@ nexus:Risk a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:concern ],
         [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedAction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:tag ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:descriptor ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskConcept ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:tag ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:tag ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isPartOf ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "The state of uncertainty associated with an AI system, that has the potential to cause harms" ;

--- a/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -1,21 +1,24 @@
 from __future__ import annotations 
+
+import re
+import sys
 from datetime import (
+    date,
     datetime,
-    date
+    time
 )
 from decimal import Decimal 
 from enum import Enum 
-import re
-import sys
 from typing import (
     Any,
     ClassVar,
+    Dict,
     List,
     Literal,
-    Dict,
     Optional,
     Union
 )
+
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -23,6 +26,8 @@ from pydantic import (
     RootModel,
     field_validator
 )
+
+
 metamodel_version = "None"
 version = "0.5.0"
 
@@ -62,7 +67,7 @@ linkml_meta = LinkMLMeta({'default_curi_maps': ['semweb_context'],
      'default_prefix': 'nexus',
      'default_range': 'string',
      'description': 'An ontology describing AI systems and their risks',
-     'id': 'http://research.ibm.com/ontologies/aiont/ai-risk-ontology',
+     'id': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology',
      'imports': ['linkml:types', 'common', 'ai_risk', 'ai_system', 'ai_eval'],
      'license': 'https://www.apache.org/licenses/LICENSE-2.0.html',
      'name': 'ai-risk-ontology',
@@ -71,7 +76,7 @@ linkml_meta = LinkMLMeta({'default_curi_maps': ['semweb_context'],
                   'linkml': {'prefix_prefix': 'linkml',
                              'prefix_reference': 'https://w3id.org/linkml/'},
                   'nexus': {'prefix_prefix': 'nexus',
-                            'prefix_reference': 'http://research.ibm.com/ontologies/aiont/'}},
+                            'prefix_reference': 'https://ibm.github.io/risk-atlas-nexus/ontology/'}},
      'source_file': 'src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml'} )
 
 class EuAiRiskCategory(str, Enum):
@@ -103,18 +108,18 @@ class Entity(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
          'class_uri': 'schema:Thing',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -124,19 +129,19 @@ class Organization(Entity):
     Any organizational entity such as a corporation, educational institution, consortium, government, etc.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Organization',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    grants_license: Optional[str] = Field(None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -146,21 +151,21 @@ class License(Entity):
     The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:License',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    version: Optional[str] = Field(None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
+    version: Optional[str] = Field(default=None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
          'domain_of': ['License', 'RiskTaxonomy'],
          'slot_uri': 'schema:version'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -170,12 +175,12 @@ class Dataset(Entity):
     A body of structured information describing some topic(s) of interest.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Dataset',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -183,17 +188,17 @@ class Dataset(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    provider: Optional[str] = Field(None, description="""A relationship to the Organization instance that provides this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'provider', 'domain_of': ['Dataset'], 'slot_uri': 'schema:provider'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    provider: Optional[str] = Field(default=None, description="""A relationship to the Organization instance that provides this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'provider', 'domain_of': ['Dataset'], 'slot_uri': 'schema:provider'} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -203,18 +208,18 @@ class Documentation(Entity):
     Documented information about a concept or other topic(s) of interest.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Documentation',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -225,22 +230,22 @@ class Fact(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
          'class_uri': 'schema:Statement',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/common'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    value: str = Field(..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
-    evidence: Optional[str] = Field(None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
+    value: str = Field(default=..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
+    evidence: Optional[str] = Field(default=None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
 
 
 class RiskTaxonomy(Entity):
     """
     A taxonomy of AI system related risks
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    version: Optional[str] = Field(None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
+    version: Optional[str] = Field(default=None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
          'domain_of': ['License', 'RiskTaxonomy'],
          'slot_uri': 'schema:version'} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -248,19 +253,19 @@ class RiskTaxonomy(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -270,21 +275,21 @@ class RiskConcept(Entity):
     An umbrella term for refering to risk, risk source, consequence and impact.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:RiskConcept',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    isDetectedBy: Optional[List[str]] = Field(None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
+    isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
          'domain_of': ['RiskConcept'],
          'inverse': 'detectsRiskConcept'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -293,50 +298,50 @@ class RiskGroup(RiskConcept, Entity):
     """
     A group of AI system related risks that are part of a risk taxonomy.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk',
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
          'mixins': ['RiskConcept'],
          'slot_usage': {'hasPart': {'description': 'A relationship where a riskgroup '
                                                    'has a risk',
                                     'name': 'hasPart',
                                     'range': 'Risk'}}})
 
-    isDefinedByTaxonomy: Optional[str] = Field(None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
+    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
          'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
          'slot_uri': 'schema:isPartOf'} })
-    closeMatch: Optional[List[str]] = Field(None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
+    closeMatch: Optional[List[str]] = Field(default=None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:closeMatch'} })
-    exactMatch: Optional[List[str]] = Field(None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
+    exactMatch: Optional[List[str]] = Field(default=None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:exactMatch'} })
-    broadMatch: Optional[List[str]] = Field(None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
+    broadMatch: Optional[List[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:broadMatch'} })
-    narrowMatch: Optional[List[str]] = Field(None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
+    narrowMatch: Optional[List[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:narrowMatch'} })
-    relatedMatch: Optional[List[str]] = Field(None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
+    relatedMatch: Optional[List[str]] = Field(default=None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:relatedMatch'} })
-    hasPart: Optional[List[str]] = Field(None, description="""A relationship where a riskgroup has a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasPart', 'domain_of': ['RiskGroup'], 'slot_uri': 'schema:hasPart'} })
-    isDetectedBy: Optional[List[str]] = Field(None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
+    hasPart: Optional[List[str]] = Field(default=None, description="""A relationship where a riskgroup has a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasPart', 'domain_of': ['RiskGroup'], 'slot_uri': 'schema:hasPart'} })
+    isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
          'domain_of': ['RiskConcept'],
          'inverse': 'detectsRiskConcept'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -346,62 +351,62 @@ class Risk(RiskConcept, Entity):
     The state of uncertainty associated with an AI system, that has the potential to cause harms
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Risk',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
          'mixins': ['RiskConcept'],
          'slot_usage': {'isPartOf': {'description': 'A relationship where a risk is '
                                                     'part of a risk group',
                                      'name': 'isPartOf',
                                      'range': 'RiskGroup'}}})
 
-    hasRelatedAction: Optional[List[str]] = Field(None, description="""A relationship where an entity relates to an action""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedAction', 'domain_of': ['Risk']} })
-    isDefinedByTaxonomy: Optional[str] = Field(None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
+    hasRelatedAction: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to an action""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedAction', 'domain_of': ['Risk']} })
+    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
          'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
          'slot_uri': 'schema:isPartOf'} })
-    isPartOf: Optional[str] = Field(None, description="""A relationship where a risk is part of a risk group""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
+    isPartOf: Optional[str] = Field(default=None, description="""A relationship where a risk is part of a risk group""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
          'domain_of': ['Risk', 'LargeLanguageModel'],
          'slot_uri': 'schema:isPartOf'} })
-    closeMatch: Optional[List[str]] = Field(None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
+    closeMatch: Optional[List[str]] = Field(default=None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:closeMatch'} })
-    exactMatch: Optional[List[str]] = Field(None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
+    exactMatch: Optional[List[str]] = Field(default=None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:exactMatch'} })
-    broadMatch: Optional[List[str]] = Field(None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
+    broadMatch: Optional[List[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:broadMatch'} })
-    narrowMatch: Optional[List[str]] = Field(None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
+    narrowMatch: Optional[List[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:narrowMatch'} })
-    relatedMatch: Optional[List[str]] = Field(None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
+    relatedMatch: Optional[List[str]] = Field(default=None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
          'domain_of': ['RiskGroup', 'Risk'],
          'slot_uri': 'skos:relatedMatch'} })
-    detectsRiskConcept: Optional[List[str]] = Field(None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources,  consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
+    detectsRiskConcept: Optional[List[str]] = Field(default=None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources,  consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
          'domain_of': ['Risk', 'RiskControl'],
          'exact_mappings': ['airo:detectsRiskConcept'],
          'inverse': 'isDetectedBy'} })
-    tag: Optional[str] = Field(None, description="""A shost version of the name""", json_schema_extra = { "linkml_meta": {'alias': 'tag', 'domain_of': ['Risk']} })
-    type: Optional[str] = Field(None, description="""Annotation whether an AI risk occurs at input or output or is non-technical.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['Risk']} })
-    phase: Optional[str] = Field(None, description="""Annotation whether an AI risk shows specifically during the training-tuning or inference phase.""", json_schema_extra = { "linkml_meta": {'alias': 'phase', 'domain_of': ['Risk']} })
-    descriptor: Optional[str] = Field(None, description="""Annotates whether an AI risk is a traditional risk, specific to or amplified by AI.""", json_schema_extra = { "linkml_meta": {'alias': 'descriptor', 'domain_of': ['Risk']} })
-    concern: Optional[str] = Field(None, description="""Some explanation about the concern related to an AI risk""", json_schema_extra = { "linkml_meta": {'alias': 'concern', 'domain_of': ['Risk']} })
-    isDetectedBy: Optional[List[str]] = Field(None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
+    tag: Optional[str] = Field(default=None, description="""A shost version of the name""", json_schema_extra = { "linkml_meta": {'alias': 'tag', 'domain_of': ['Risk']} })
+    type: Optional[str] = Field(default=None, description="""Annotation whether an AI risk occurs at input or output or is non-technical.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['Risk']} })
+    phase: Optional[str] = Field(default=None, description="""Annotation whether an AI risk shows specifically during the training-tuning or inference phase.""", json_schema_extra = { "linkml_meta": {'alias': 'phase', 'domain_of': ['Risk']} })
+    descriptor: Optional[str] = Field(default=None, description="""Annotates whether an AI risk is a traditional risk, specific to or amplified by AI.""", json_schema_extra = { "linkml_meta": {'alias': 'descriptor', 'domain_of': ['Risk']} })
+    concern: Optional[str] = Field(default=None, description="""Some explanation about the concern related to an AI risk""", json_schema_extra = { "linkml_meta": {'alias': 'concern', 'domain_of': ['Risk']} })
+    isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
          'domain_of': ['RiskConcept'],
          'inverse': 'detectsRiskConcept'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -411,25 +416,25 @@ class RiskControl(Entity):
     A measure that maintains and/or modifies risk (and risk concepts)
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:RiskControl',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    detectsRiskConcept: Optional[List[str]] = Field(None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources,  consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
+    detectsRiskConcept: Optional[List[str]] = Field(default=None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources,  consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
          'domain_of': ['Risk', 'RiskControl'],
          'exact_mappings': ['airo:detectsRiskConcept'],
          'inverse': 'isDetectedBy'} })
-    isDefinedByTaxonomy: Optional[str] = Field(None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
+    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
          'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
          'slot_uri': 'schema:isPartOf'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -438,10 +443,10 @@ class Action(Entity):
     """
     Action to remediate a risk
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    hasRelatedRisk: Optional[List[str]] = Field(None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasRelatedRisk: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -449,20 +454,20 @@ class Action(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    isDefinedByTaxonomy: Optional[str] = Field(None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
+    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
          'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
          'slot_uri': 'schema:isPartOf'} })
-    hasAiActorTask: Optional[List[str]] = Field(None, description="""Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed will apply to every suggested action in the subcategory (i.e., some apply to AI development and others apply to AI deployment).""", json_schema_extra = { "linkml_meta": {'alias': 'hasAiActorTask', 'domain_of': ['Action']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    hasAiActorTask: Optional[List[str]] = Field(default=None, description="""Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed will apply to every suggested action in the subcategory (i.e., some apply to AI development and others apply to AI deployment).""", json_schema_extra = { "linkml_meta": {'alias': 'hasAiActorTask', 'domain_of': ['Action']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -472,7 +477,7 @@ class AiEval(Entity):
     An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a question or a combination of such entities.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dqv:Metric',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_eval',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
          'slot_usage': {'isComposedOf': {'description': 'A relationship indicating '
                                                         'that an AI evaluation maybe '
                                                         'composed of other AI '
@@ -482,7 +487,7 @@ class AiEval(Entity):
                                          'name': 'isComposedOf',
                                          'range': 'AiEval'}}})
 
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -490,23 +495,23 @@ class AiEval(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[List[str]] = Field(None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasUnitxtCard: Optional[str] = Field(None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasDataset: Optional[List[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
+    hasUnitxtCard: Optional[str] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[List[str]] = Field(None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    hasRelatedRisk: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
+    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -516,24 +521,24 @@ class AiEvalResult(Fact, Entity):
     The result of an evaluation for a specific AI model.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dqv:QualityMeasurement',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_eval',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
          'mixins': ['Fact']})
 
-    isResultOf: Optional[str] = Field(None, description="""A relationship indicating that an entity is the result of an AI evaluation.""", json_schema_extra = { "linkml_meta": {'alias': 'isResultOf',
+    isResultOf: Optional[str] = Field(default=None, description="""A relationship indicating that an entity is the result of an AI evaluation.""", json_schema_extra = { "linkml_meta": {'alias': 'isResultOf',
          'domain_of': ['AiEvalResult'],
          'slot_uri': 'dqv:isMeasurementOf'} })
-    value: str = Field(..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
-    evidence: Optional[str] = Field(None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    value: str = Field(default=..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
+    evidence: Optional[str] = Field(default=None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -542,10 +547,10 @@ class Question(AiEval):
     """
     An evaluation where a question has to be answered
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_eval'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval'})
 
-    text: str = Field(..., description="""The question itself""", json_schema_extra = { "linkml_meta": {'alias': 'text', 'domain_of': ['Question']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    text: str = Field(default=..., description="""The question itself""", json_schema_extra = { "linkml_meta": {'alias': 'text', 'domain_of': ['Question']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -553,23 +558,23 @@ class Question(AiEval):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[List[str]] = Field(None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasUnitxtCard: Optional[str] = Field(None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasDataset: Optional[List[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
+    hasUnitxtCard: Optional[str] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[List[str]] = Field(None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    hasRelatedRisk: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
+    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -578,10 +583,10 @@ class Questionnaire(AiEval):
     """
     A questionnaire groups questions
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_eval',
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
          'slot_usage': {'composed_of': {'name': 'composed_of', 'range': 'Question'}}})
 
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -589,23 +594,23 @@ class Questionnaire(AiEval):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[List[str]] = Field(None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasUnitxtCard: Optional[str] = Field(None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasDataset: Optional[List[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
+    hasUnitxtCard: Optional[str] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[List[str]] = Field(None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    hasRelatedRisk: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk', 'domain_of': ['Action', 'AiEval']} })
+    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -615,19 +620,19 @@ class AiOffice(Organization):
     The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office)
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Organization',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/eu_ai_act'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/eu_ai_act'})
 
-    grants_license: Optional[str] = Field(None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -637,11 +642,11 @@ class BaseAi(Entity):
     Any type of AI, be it a LLM, RL agent, SVM, etc.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    producer: Optional[str] = Field(None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[List[str]] = Field(None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
+    hasModelCard: Optional[List[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -649,23 +654,23 @@ class BaseAi(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[List[str]] = Field(None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
+    performsTask: Optional[List[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
+    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
          'domain_of': ['BaseAi'],
          'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -675,7 +680,7 @@ class AiSystem(BaseAi):
     A compound AI System composed of one or more AI capablities. ChatGPT is an example of an AI system which deploys multiple GPT AI models.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AISystem',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
          'slot_usage': {'isComposedOf': {'description': 'Relationship indicating the '
                                                         'AI components from which a '
                                                         'complete AI system is '
@@ -683,11 +688,11 @@ class AiSystem(BaseAi):
                                          'name': 'isComposedOf',
                                          'range': 'BaseAi'}}})
 
-    hasEuAiSystemType: Optional[AiSystemType] = Field(None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
-    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
-    producer: Optional[str] = Field(None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[List[str]] = Field(None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasEuAiSystemType: Optional[AiSystemType] = Field(default=None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
+    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(default=None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
+    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
+    hasModelCard: Optional[List[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -695,23 +700,23 @@ class AiSystem(BaseAi):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[List[str]] = Field(None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
+    performsTask: Optional[List[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
+    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
          'domain_of': ['BaseAi'],
          'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -720,17 +725,17 @@ class AiAgent(AiSystem):
     """
     An artificial intelligence (AI) agent refers to a system or program that is capable of autonomously performing tasks on behalf of a user or another system by designing its workflow and utilizing available tools.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system',
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
          'slot_usage': {'isProvidedBy': {'description': 'A relationship indicating the '
                                                         'AI agent has been provided by '
                                                         'an AI systems provider.',
                                          'name': 'isProvidedBy'}}})
 
-    hasEuAiSystemType: Optional[AiSystemType] = Field(None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
-    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
-    producer: Optional[str] = Field(None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[List[str]] = Field(None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasEuAiSystemType: Optional[AiSystemType] = Field(default=None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
+    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(default=None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
+    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
+    hasModelCard: Optional[List[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -738,23 +743,23 @@ class AiAgent(AiSystem):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[List[str]] = Field(None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(None, description="""A relationship indicating the AI agent has been provided by an AI systems provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
+    performsTask: Optional[List[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
+    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI agent has been provided by an AI systems provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
          'domain_of': ['BaseAi'],
          'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -763,23 +768,23 @@ class AiModel(BaseAi):
     """
     A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclassed by model types (see LargeLanguageModel).
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    hasEvaluation: Optional[List[AiEvalResult]] = Field(None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
+    hasEvaluation: Optional[List[AiEvalResult]] = Field(default=None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
          'domain_of': ['AiModel'],
          'slot_uri': 'dqv:hasQualityMeasurement'} })
-    architecture: Optional[str] = Field(None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
-    gpu_hours: Optional[int] = Field(None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
-    power_consumption_w: Optional[int] = Field(None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
-    carbon_emitted: Optional[float] = Field(None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
+    architecture: Optional[str] = Field(default=None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
+    gpu_hours: Optional[int] = Field(default=None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
+    power_consumption_w: Optional[int] = Field(default=None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
+    carbon_emitted: Optional[float] = Field(default=None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
          'domain_of': ['AiModel'],
          'unit': {'descriptive_name': 'tons of CO2 equivalent', 'symbol': 't CO2-eq'}} })
-    hasRiskControl: Optional[List[str]] = Field(None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
+    hasRiskControl: Optional[List[str]] = Field(default=None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
          'domain_of': ['AiModel'],
          'slot_uri': 'airo:hasRiskControl'} })
-    producer: Optional[str] = Field(None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[List[str]] = Field(None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
+    hasModelCard: Optional[List[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -787,23 +792,23 @@ class AiModel(BaseAi):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[List[str]] = Field(None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
+    performsTask: Optional[List[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
+    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
          'domain_of': ['BaseAi'],
          'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -813,41 +818,41 @@ class LargeLanguageModel(AiModel):
     A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['LLM'],
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
          'slot_usage': {'isPartOf': {'description': 'Annotation that a Large Language '
                                                     'model is part of a family of '
                                                     'models',
                                      'name': 'isPartOf',
                                      'range': 'LargeLanguageModelFamily'}}})
 
-    numParameters: Optional[int] = Field(None, description="""A property indicating the number of parameters in a LLM.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numParameters', 'domain_of': ['LargeLanguageModel']} })
-    numTrainingTokens: Optional[int] = Field(None, description="""The number of tokens a AI model was trained on.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numTrainingTokens', 'domain_of': ['LargeLanguageModel']} })
-    contextWindowSize: Optional[int] = Field(None, description="""The total length, in bytes, of an AI model's context window.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'contextWindowSize', 'domain_of': ['LargeLanguageModel']} })
-    hasInputModality: Optional[List[str]] = Field(None, description="""A relationship indicating the input modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasInputModality', 'domain_of': ['LargeLanguageModel']} })
-    hasOutputModality: Optional[List[str]] = Field(None, description="""A relationship indicating the output modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasOutputModality', 'domain_of': ['LargeLanguageModel']} })
-    hasTrainingData: Optional[List[str]] = Field(None, description="""A relationship indicating the datasets an AI model was trained on.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTrainingData',
+    numParameters: Optional[int] = Field(default=None, description="""A property indicating the number of parameters in a LLM.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numParameters', 'domain_of': ['LargeLanguageModel']} })
+    numTrainingTokens: Optional[int] = Field(default=None, description="""The number of tokens a AI model was trained on.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numTrainingTokens', 'domain_of': ['LargeLanguageModel']} })
+    contextWindowSize: Optional[int] = Field(default=None, description="""The total length, in bytes, of an AI model's context window.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'contextWindowSize', 'domain_of': ['LargeLanguageModel']} })
+    hasInputModality: Optional[List[str]] = Field(default=None, description="""A relationship indicating the input modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasInputModality', 'domain_of': ['LargeLanguageModel']} })
+    hasOutputModality: Optional[List[str]] = Field(default=None, description="""A relationship indicating the output modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasOutputModality', 'domain_of': ['LargeLanguageModel']} })
+    hasTrainingData: Optional[List[str]] = Field(default=None, description="""A relationship indicating the datasets an AI model was trained on.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTrainingData',
          'domain_of': ['LargeLanguageModel'],
          'slot_uri': 'airo:hasTrainingData'} })
-    fine_tuning: Optional[str] = Field(None, description="""A description of the fine-tuning mechanism(s) applied to a model.""", json_schema_extra = { "linkml_meta": {'alias': 'fine_tuning', 'domain_of': ['LargeLanguageModel']} })
-    supported_languages: Optional[List[str]] = Field(None, description="""A list of languages, expressed as ISO two letter codes. For example, 'jp, fr, en, de'""", json_schema_extra = { "linkml_meta": {'alias': 'supported_languages', 'domain_of': ['LargeLanguageModel']} })
-    isPartOf: Optional[str] = Field(None, description="""Annotation that a Large Language model is part of a family of models""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
+    fine_tuning: Optional[str] = Field(default=None, description="""A description of the fine-tuning mechanism(s) applied to a model.""", json_schema_extra = { "linkml_meta": {'alias': 'fine_tuning', 'domain_of': ['LargeLanguageModel']} })
+    supported_languages: Optional[List[str]] = Field(default=None, description="""A list of languages, expressed as ISO two letter codes. For example, 'jp, fr, en, de'""", json_schema_extra = { "linkml_meta": {'alias': 'supported_languages', 'domain_of': ['LargeLanguageModel']} })
+    isPartOf: Optional[str] = Field(default=None, description="""Annotation that a Large Language model is part of a family of models""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
          'domain_of': ['Risk', 'LargeLanguageModel'],
          'slot_uri': 'schema:isPartOf'} })
-    hasEvaluation: Optional[List[AiEvalResult]] = Field(None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
+    hasEvaluation: Optional[List[AiEvalResult]] = Field(default=None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
          'domain_of': ['AiModel'],
          'slot_uri': 'dqv:hasQualityMeasurement'} })
-    architecture: Optional[str] = Field(None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
-    gpu_hours: Optional[int] = Field(None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
-    power_consumption_w: Optional[int] = Field(None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
-    carbon_emitted: Optional[float] = Field(None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
+    architecture: Optional[str] = Field(default=None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
+    gpu_hours: Optional[int] = Field(default=None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
+    power_consumption_w: Optional[int] = Field(default=None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
+    carbon_emitted: Optional[float] = Field(default=None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
          'domain_of': ['AiModel'],
          'unit': {'descriptive_name': 'tons of CO2 equivalent', 'symbol': 't CO2-eq'}} })
-    hasRiskControl: Optional[List[str]] = Field(None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
+    hasRiskControl: Optional[List[str]] = Field(default=None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
          'domain_of': ['AiModel'],
          'slot_uri': 'airo:hasRiskControl'} })
-    producer: Optional[str] = Field(None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[List[str]] = Field(None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
+    hasModelCard: Optional[List[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -855,23 +860,23 @@ class LargeLanguageModel(AiModel):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
+    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
          'domain_of': ['Dataset', 'RiskTaxonomy', 'AiEval', 'BaseAi'],
          'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[List[str]] = Field(None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
+    performsTask: Optional[List[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
+    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
          'domain_of': ['BaseAi'],
          'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -880,9 +885,9 @@ class LargeLanguageModelFamily(Entity):
     """
     A large language model family is a set of models that are provided by the same AI systems provider and are built around the same architecture, but differ e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite models.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    hasDocumentation: Optional[List[str]] = Field(None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
+    hasDocumentation: Optional[List[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
          'domain_of': ['Dataset',
                        'RiskTaxonomy',
                        'Action',
@@ -890,16 +895,16 @@ class LargeLanguageModelFamily(Entity):
                        'BaseAi',
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -909,18 +914,18 @@ class AiTask(Entity):
     A task, such as summarization and classification, performed by an AI.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AiCapability',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -931,18 +936,18 @@ class AiLifecyclePhase(Entity):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
          'class_uri': 'airo:AILifecyclePhase',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -951,18 +956,18 @@ class DataPreprocessing(AiLifecyclePhase):
     """
     Data transformations, such as PI filtering, performed to ensure high quality of AI model training data.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -971,18 +976,18 @@ class AiModelValidation(AiLifecyclePhase):
     """
     AI model validation steps that have been performed after the model training to ensure high AI model quality.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -992,19 +997,19 @@ class AiProvider(Organization):
     A provider under the AI Act is defined by Article 3(3) as a natural or legal person or body that develops an AI system or general-purpose AI model or has an AI system or general-purpose AI model developed; and places that system or model on the market, or puts that system into service, under the provider's own name or trademark, whether for payment or free for charge.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AIProvider',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    grants_license: Optional[str] = Field(None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -1014,18 +1019,18 @@ class Modality(Entity):
     A modality supported by an Ai component. Examples include text, image, video.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Modality',
-         'from_schema': 'http://research.ibm.com/ontologies/aiont/ai_system'})
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
          'domain_of': ['Entity'],
          'slot_uri': 'schema:dateModified'} })
 
@@ -1034,23 +1039,23 @@ class Container(ConfiguredBaseModel):
     """
     An umbrella object that holds the ontology class instances
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://research.ibm.com/ontologies/aiont/ai-risk-ontology',
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology',
          'tree_root': True})
 
-    organizations: Optional[List[Organization]] = Field(None, description="""A list of organizations""", json_schema_extra = { "linkml_meta": {'alias': 'organizations', 'domain_of': ['Container']} })
-    licenses: Optional[List[License]] = Field(None, description="""A list of licenses""", json_schema_extra = { "linkml_meta": {'alias': 'licenses', 'domain_of': ['Container']} })
-    modalities: Optional[List[Modality]] = Field(None, description="""A list of AI modalities""", json_schema_extra = { "linkml_meta": {'alias': 'modalities', 'domain_of': ['Container']} })
-    aitasks: Optional[List[AiTask]] = Field(None, description="""A list of AI tasks""", json_schema_extra = { "linkml_meta": {'alias': 'aitasks', 'domain_of': ['Container']} })
-    documents: Optional[List[Documentation]] = Field(None, description="""A list of documents""", json_schema_extra = { "linkml_meta": {'alias': 'documents', 'domain_of': ['Container']} })
-    datasets: Optional[List[Dataset]] = Field(None, description="""A list of data sets""", json_schema_extra = { "linkml_meta": {'alias': 'datasets', 'domain_of': ['Container']} })
-    taxonomies: Optional[List[RiskTaxonomy]] = Field(None, description="""A list of AI risk taxonomies""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomies', 'domain_of': ['Container']} })
-    riskgroups: Optional[List[RiskGroup]] = Field(None, description="""A list of AI risk groups""", json_schema_extra = { "linkml_meta": {'alias': 'riskgroups', 'domain_of': ['Container']} })
-    risks: Optional[List[Risk]] = Field(None, description="""A list of AI risks""", json_schema_extra = { "linkml_meta": {'alias': 'risks', 'domain_of': ['Container']} })
-    riskcontrols: Optional[List[RiskControl]] = Field(None, description="""A list of AI risk controls""", json_schema_extra = { "linkml_meta": {'alias': 'riskcontrols', 'domain_of': ['Container']} })
-    actions: Optional[List[Action]] = Field(None, description="""A list of risk related actions""", json_schema_extra = { "linkml_meta": {'alias': 'actions', 'domain_of': ['Container']} })
-    evaluations: Optional[List[AiEval]] = Field(None, description="""A list of AI evaluation methods""", json_schema_extra = { "linkml_meta": {'alias': 'evaluations', 'domain_of': ['Container']} })
-    aimodelfamilies: Optional[List[LargeLanguageModelFamily]] = Field(None, description="""A list of AI model families""", json_schema_extra = { "linkml_meta": {'alias': 'aimodelfamilies', 'domain_of': ['Container']} })
-    aimodels: Optional[List[LargeLanguageModel]] = Field(None, description="""A list of AI models""", json_schema_extra = { "linkml_meta": {'alias': 'aimodels', 'domain_of': ['Container']} })
+    organizations: Optional[List[Organization]] = Field(default=None, description="""A list of organizations""", json_schema_extra = { "linkml_meta": {'alias': 'organizations', 'domain_of': ['Container']} })
+    licenses: Optional[List[License]] = Field(default=None, description="""A list of licenses""", json_schema_extra = { "linkml_meta": {'alias': 'licenses', 'domain_of': ['Container']} })
+    modalities: Optional[List[Modality]] = Field(default=None, description="""A list of AI modalities""", json_schema_extra = { "linkml_meta": {'alias': 'modalities', 'domain_of': ['Container']} })
+    aitasks: Optional[List[AiTask]] = Field(default=None, description="""A list of AI tasks""", json_schema_extra = { "linkml_meta": {'alias': 'aitasks', 'domain_of': ['Container']} })
+    documents: Optional[List[Documentation]] = Field(default=None, description="""A list of documents""", json_schema_extra = { "linkml_meta": {'alias': 'documents', 'domain_of': ['Container']} })
+    datasets: Optional[List[Dataset]] = Field(default=None, description="""A list of data sets""", json_schema_extra = { "linkml_meta": {'alias': 'datasets', 'domain_of': ['Container']} })
+    taxonomies: Optional[List[RiskTaxonomy]] = Field(default=None, description="""A list of AI risk taxonomies""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomies', 'domain_of': ['Container']} })
+    riskgroups: Optional[List[RiskGroup]] = Field(default=None, description="""A list of AI risk groups""", json_schema_extra = { "linkml_meta": {'alias': 'riskgroups', 'domain_of': ['Container']} })
+    risks: Optional[List[Risk]] = Field(default=None, description="""A list of AI risks""", json_schema_extra = { "linkml_meta": {'alias': 'risks', 'domain_of': ['Container']} })
+    riskcontrols: Optional[List[RiskControl]] = Field(default=None, description="""A list of AI risk controls""", json_schema_extra = { "linkml_meta": {'alias': 'riskcontrols', 'domain_of': ['Container']} })
+    actions: Optional[List[Action]] = Field(default=None, description="""A list of risk related actions""", json_schema_extra = { "linkml_meta": {'alias': 'actions', 'domain_of': ['Container']} })
+    evaluations: Optional[List[AiEval]] = Field(default=None, description="""A list of AI evaluation methods""", json_schema_extra = { "linkml_meta": {'alias': 'evaluations', 'domain_of': ['Container']} })
+    aimodelfamilies: Optional[List[LargeLanguageModelFamily]] = Field(default=None, description="""A list of AI model families""", json_schema_extra = { "linkml_meta": {'alias': 'aimodelfamilies', 'domain_of': ['Container']} })
+    aimodels: Optional[List[LargeLanguageModel]] = Field(default=None, description="""A list of AI models""", json_schema_extra = { "linkml_meta": {'alias': 'aimodels', 'domain_of': ['Container']} })
 
 
 # Model rebuild

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/ai-risk-ontology
+id: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 name: ai-risk-ontology
 version: 0.5.0
 license: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -15,7 +15,7 @@ imports:
 prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
   
 default_range: string
 default_prefix: nexus

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_eval.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_eval.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/ai_eval
+id: https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval
 name: ai_eval
 description:
   Defines vocabulary relating to AI model evaluation
@@ -10,7 +10,7 @@ default_curi_maps:
   - semweb_context
 prefixes:
   linkml: https://w3id.org/linkml/
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
   dqv: https://www.w3.org/TR/vocab-dqv/ 
   skos: http://www.w3.org/2004/02/skos/core/
 default_range: string

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_risk.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_risk.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/ai_risk
+id: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
 name: ai_risk
 description:
   Vocabulary describing AI risks as used by IBM Risk Atlas
@@ -10,7 +10,7 @@ imports:
 prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
 default_range: string
 default_prefix: nexus
 

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_system.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_system.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/ai_system
+id: https://ibm.github.io/risk-atlas-nexus/ontology/ai_system
 name: ai_system
 description:
   An ontology describing AI systems
@@ -14,7 +14,7 @@ imports:
 prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
   
 default_range: string
 default_prefix: nexus

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/common.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/common.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/common
+id: https://ibm.github.io/risk-atlas-nexus/ontology/common
 name: common
 description:
   A core schema supporting the AI Risk Model ontology
@@ -9,7 +9,7 @@ imports:
 prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
 
 default_range: string
 default_prefix: nexus

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/energy.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/energy.yaml
@@ -1,11 +1,11 @@
-id: http://research.ibm.com/ontologies/aiont/energy
+id: https://ibm.github.io/risk-atlas-nexus/ontology/energy
 name: energy
 description:
   Defines vocabularies relating to energy consumptionimports:
   - linkml:types
 prefixes:
   linkml: https://w3id.org/linkml/
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
 
 default_range: string
 default_prefix: nexus

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/eu_ai_act.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/eu_ai_act.yaml
@@ -1,4 +1,4 @@
-id: http://research.ibm.com/ontologies/aiont/eu_ai_act
+id: https://ibm.github.io/risk-atlas-nexus/ontology/eu_ai_act
 name: eu_ai_act
 description:
   Vocabulary pertaining to the EU AI Act
@@ -9,7 +9,7 @@ default_curi_maps:
   - semweb_context
 prefixes:
   linkml: https://w3id.org/linkml/
-  nexus: http://research.ibm.com/ontologies/aiont/
+  nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
 
 default_range: string
 default_prefix: nexus


### PR DESCRIPTION
## Status
**READY**

## Description

Change the nexus schema URL from:
from : http://research.ibm.com/ontologies/aiont/ai-risk-ontology
to : https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology

Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>

## Impacted Areas in Application
Schema and generated yaml/graph


## Checklist
- [x] Automated tests exist
- [x] Local unit tests performed
- [x] Documentation exists [link]()
- [ ] Local git lint performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided