### PR TITLE
fix: Add missing OpenAI min version in project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "logzero",
     "python-dotenv",
     "datasets",
-    "openai",
+    "openai>=1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Signed-off-by: Frank Bagehorn <fba@zurich.ibm.com>

<!-- PLEASE MOVE COMMIT DETAIL INTO THE TEMPLATE BELOW -->

<!-- Commit Message Title
* When opening this PR, the raiser should set the title of this PR to the first line of their desired commit message, e.g:
```
feat|fix|docs|style|refactor|perf|test|chore: changed function X
```
* The reviewer should ensure that the first commit message field is of this form when performing the `squash and merge` from this page.
-->

---
## Status
**READY**

## Description
<!-- Commit Message Description
```
# When opening this PR, the raiser should replace this text with the remaining lines of their desired commit message, e.g:

Further details of the code going into the commit

Contributes to: IBM/risk-atlas-nexus#XYZ
Closes: IBM/risk-atlas-nexus#XYZ

Signed-off-by: Your Name <email@ie.ibm.com>
```
* The reviewer should copy the above text into the extended description field when performing the `squash and merge` from this page. 
-->
There is a dependency on openai.types which was introduced with version 1.0. Therefore the `pyproject.toml` dependencies should reflect that minimum required version.

## Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

### Screenshots
<!-- For UI items, please provide screenshots demonstrating the work completed -->

## Which issue(s) does this pull-request fix?
<!-- Please include a link to the issue -->
<!-- Contributes to: IBM/risk-atlas-nexus# -->
<!-- Closes: IBM/risk-atlas-nexus# -->

## Any special notes for your reviewer?

--- 

## Checklist
- [ ] Automated tests exist
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided