### PR TITLE
feat: add risk incidents to schema

### DIFF
--- a/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
+++ b/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
@@ -205,10 +205,46 @@
     "print(f\"\\n# Get a risk control by ID, 'gg-function-call-detection' \") \n",
     "print(dict(a_risk_control))\n",
     "\n",
-    "# Get any risk controls for the IBM risk atlas risk harmful output\n",
+    "# Get any risk controls for the risk granite-function-call\n",
     "print(f\"\\n# Get the linked risk controls by ID for 'granite-function-call\") \n",
     "controls_for_granite_function_call = ran.get_related_risk_controls(id='granite-function-call')\n",
     "print(controls_for_granite_function_call) # 1 expected\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1.5 Risk Incidents\n",
+    "\n",
+    "Risk incidents can also be modelled using the Risk Atlas Nexus.  We can view all risk incidents available, or drill down into a specific incident.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_risk_incidents = ran.get_risk_incidents()\n",
+    "print(f\"\\n# Total risk incidents available : {len(all_risk_incidents)}\") # 0\n",
+    "\n",
+    "# Let's just print out a few for now\n",
+    "print(f\"\\n# First 2 risk incidents in list \") \n",
+    "print(all_risk_incidents[:2])\n",
+    "\n",
+    "# View an individual risk incident by ID. Each risk incident is returned as a pydantic \"RiskIncident\" object as defined in risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology\n",
+    "a_risk_incident = ran.get_risk_incident(id='incident-1')\n",
+    "print(f\"\\n# Get a risk incident by ID, 'incident-1'\") \n",
+    "if a_risk_incident:\n",
+    "    print(dict(a_risk_incident))\n",
+    "else:\n",
+    "    print(f\"\\n# Risk incident 'incident-1' not found\") \n",
+    "\n",
+    "# Get any risk incidents which are linked to the IBM risk atlas risk harmful output\n",
+    "print(f\"\\n# Get the linked risk incidents by ID for 'incident-1\") \n",
+    "linked_incidents = ran.get_related_risk_incidents(risk_id='atlas-toxic-output')\n",
+    "print(linked_incidents) # 0 expected\n"
    ]
   },
   {

--- a/docs/ontology/Action.md
+++ b/docs/ontology/Action.md
@@ -213,6 +213,7 @@ attributes:
     - Risk
     - RiskControl
     - Action
+    - RiskIncident
     range: RiskTaxonomy
   hasAiActorTask:
     name: hasAiActorTask

--- a/docs/ontology/Consequence.md
+++ b/docs/ontology/Consequence.md
@@ -1,15 +1,10 @@
 
 
-# Class: RiskTaxonomy
-
-
-_A taxonomy of AI system related risks_
+# Class: Consequence
 
 
 
-
-
-URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
+URI: [dpv:Consequence](https://w3c.github.io/dpv/2.1/dpv/#Consequence)
 
 
 
@@ -18,42 +13,22 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ```mermaid
  classDiagram
-    class RiskTaxonomy
-    click RiskTaxonomy href "../RiskTaxonomy"
-      Entity <|-- RiskTaxonomy
+    class Consequence
+    click Consequence href "../Consequence"
+      Entity <|-- Consequence
         click Entity href "../Entity"
       
-      RiskTaxonomy : dateCreated
+      Consequence : dateCreated
         
-      RiskTaxonomy : dateModified
+      Consequence : dateModified
         
-      RiskTaxonomy : description
+      Consequence : description
         
-      RiskTaxonomy : hasDocumentation
+      Consequence : id
         
-          
-    
-    
-    RiskTaxonomy --> "*" Documentation : hasDocumentation
-    click Documentation href "../Documentation"
-
+      Consequence : name
         
-      RiskTaxonomy : hasLicense
-        
-          
-    
-    
-    RiskTaxonomy --> "0..1" License : hasLicense
-    click License href "../License"
-
-        
-      RiskTaxonomy : id
-        
-      RiskTaxonomy : name
-        
-      RiskTaxonomy : url
-        
-      RiskTaxonomy : version
+      Consequence : url
         
       
 ```
@@ -64,7 +39,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ## Inheritance
 * [Entity](Entity.md)
-    * **RiskTaxonomy**
+    * **Consequence**
 
 
 
@@ -72,9 +47,6 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [version](version.md) | 0..1 <br/> [String](String.md) | The version of the entity embodied by a specified resource | direct |
-| [hasDocumentation](hasDocumentation.md) | * <br/> [Documentation](Documentation.md) | Indicates documentation associated with an entity | direct |
-| [hasLicense](hasLicense.md) | 0..1 <br/> [License](License.md) | Indicates licenses associated with a resource | direct |
 | [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
@@ -90,12 +62,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
-| [Container](Container.md) | [taxonomies](taxonomies.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskGroup](RiskGroup.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Risk](Risk.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskControl](RiskControl.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Action](Action.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskIncident](RiskIncident.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
+| [RiskIncident](RiskIncident.md) | [hasConsequence](hasConsequence.md) | range | [Consequence](Consequence.md) |
 
 
 
@@ -122,8 +89,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:RiskTaxonomy |
-| native | nexus:RiskTaxonomy |
+| self | dpv:Consequence |
+| native | nexus:Consequence |
 
 
 
@@ -139,14 +106,10 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Consequence
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
-slots:
-- version
-- hasDocumentation
-- hasLicense
+class_uri: dpv:Consequence
 
 ```
 </details>
@@ -155,55 +118,10 @@ slots:
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Consequence
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
-  version:
-    name: version
-    description: The version of the entity embodied by a specified resource.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: schema:version
-    alias: version
-    owner: RiskTaxonomy
-    domain_of:
-    - License
-    - RiskTaxonomy
-    range: string
-  hasDocumentation:
-    name: hasDocumentation
-    description: Indicates documentation associated with an entity.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasDocumentation
-    alias: hasDocumentation
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - Action
-    - AiEval
-    - BaseAi
-    - LargeLanguageModelFamily
-    range: Documentation
-    multivalued: true
-    inlined: false
-  hasLicense:
-    name: hasLicense
-    description: Indicates licenses associated with a resource
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasLicense
-    alias: hasLicense
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - AiEval
-    - BaseAi
-    range: License
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
@@ -213,7 +131,7 @@ attributes:
     slot_uri: schema:identifier
     identifier: true
     alias: id
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: string
@@ -225,7 +143,7 @@ attributes:
     rank: 1000
     slot_uri: schema:name
     alias: name
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: string
@@ -236,7 +154,7 @@ attributes:
     rank: 1000
     slot_uri: schema:description
     alias: description
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: string
@@ -247,7 +165,7 @@ attributes:
     rank: 1000
     slot_uri: schema:url
     alias: url
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: uri
@@ -258,7 +176,7 @@ attributes:
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: date
@@ -270,11 +188,12 @@ attributes:
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified
-    owner: RiskTaxonomy
+    owner: Consequence
     domain_of:
     - Entity
     range: date
     required: false
+class_uri: dpv:Consequence
 
 ```
 </details>

--- a/docs/ontology/Container.md
+++ b/docs/ontology/Container.md
@@ -128,6 +128,15 @@ URI: [nexus:Container](https://ibm.github.io/risk-atlas-nexus/ontology/Container
     click RiskGroup href "../RiskGroup"
 
         
+      Container : riskincidents
+        
+          
+    
+    
+    Container --> "*" RiskIncident : riskincidents
+    click RiskIncident href "../RiskIncident"
+
+        
       Container : risks
         
           
@@ -169,6 +178,7 @@ URI: [nexus:Container](https://ibm.github.io/risk-atlas-nexus/ontology/Container
 | [riskgroups](riskgroups.md) | * <br/> [RiskGroup](RiskGroup.md) | A list of AI risk groups | direct |
 | [risks](risks.md) | * <br/> [Risk](Risk.md) | A list of AI risks | direct |
 | [riskcontrols](riskcontrols.md) | * <br/> [RiskControl](RiskControl.md) | A list of AI risk controls | direct |
+| [riskincidents](riskincidents.md) | * <br/> [RiskIncident](RiskIncident.md) | A list of AI risk incidents | direct |
 | [actions](actions.md) | * <br/> [Action](Action.md) | A list of risk related actions | direct |
 | [evaluations](evaluations.md) | * <br/> [AiEval](AiEval.md) | A list of AI evaluation methods | direct |
 | [aimodelfamilies](aimodelfamilies.md) | * <br/> [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A list of AI model families | direct |
@@ -330,6 +340,17 @@ attributes:
     domain_of:
     - Container
     range: RiskControl
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  riskincidents:
+    name: riskincidents
+    description: A list of AI risk incidents
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain_of:
+    - Container
+    range: RiskIncident
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -517,6 +538,19 @@ attributes:
     domain_of:
     - Container
     range: RiskControl
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  riskincidents:
+    name: riskincidents
+    description: A list of AI risk incidents
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    alias: riskincidents
+    owner: Container
+    domain_of:
+    - Container
+    range: RiskIncident
     multivalued: true
     inlined: true
     inlined_as_list: true

--- a/docs/ontology/Entity.md
+++ b/docs/ontology/Entity.md
@@ -42,6 +42,18 @@ URI: [schema:Thing](http://schema.org/Thing)
         click RiskControl href "../RiskControl"
       Entity <|-- Action
         click Action href "../Action"
+      Entity <|-- RiskIncident
+        click RiskIncident href "../RiskIncident"
+      Entity <|-- Impact
+        click Impact href "../Impact"
+      Entity <|-- IncidentStatus
+        click IncidentStatus href "../IncidentStatus"
+      Entity <|-- Severity
+        click Severity href "../Severity"
+      Entity <|-- Likelihood
+        click Likelihood href "../Likelihood"
+      Entity <|-- Consequence
+        click Consequence href "../Consequence"
       Entity <|-- AiEval
         click AiEval href "../AiEval"
       Entity <|-- AiEvalResult
@@ -88,6 +100,12 @@ URI: [schema:Thing](http://schema.org/Thing)
     * [RiskConcept](RiskConcept.md)
     * [RiskControl](RiskControl.md) [ [RiskConcept](RiskConcept.md)]
     * [Action](Action.md)
+    * [RiskIncident](RiskIncident.md) [ [RiskConcept](RiskConcept.md)]
+    * [Impact](Impact.md) [ [RiskConcept](RiskConcept.md)]
+    * [IncidentStatus](IncidentStatus.md)
+    * [Severity](Severity.md)
+    * [Likelihood](Likelihood.md)
+    * [Consequence](Consequence.md)
     * [AiEval](AiEval.md)
     * [AiEvalResult](AiEvalResult.md) [ [Fact](Fact.md)]
     * [BaseAi](BaseAi.md)

--- a/docs/ontology/Impact.md
+++ b/docs/ontology/Impact.md
@@ -1,15 +1,10 @@
 
 
-# Class: RiskTaxonomy
-
-
-_A taxonomy of AI system related risks_
+# Class: Impact
 
 
 
-
-
-URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
+URI: [dpv:Impact](https://w3c.github.io/dpv/2.1/dpv/#Impact)
 
 
 
@@ -18,42 +13,33 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ```mermaid
  classDiagram
-    class RiskTaxonomy
-    click RiskTaxonomy href "../RiskTaxonomy"
-      Entity <|-- RiskTaxonomy
+    class Impact
+    click Impact href "../Impact"
+      RiskConcept <|-- Impact
+        click RiskConcept href "../RiskConcept"
+      Entity <|-- Impact
         click Entity href "../Entity"
       
-      RiskTaxonomy : dateCreated
+      Impact : dateCreated
         
-      RiskTaxonomy : dateModified
+      Impact : dateModified
         
-      RiskTaxonomy : description
+      Impact : description
         
-      RiskTaxonomy : hasDocumentation
+      Impact : id
         
-          
-    
-    
-    RiskTaxonomy --> "*" Documentation : hasDocumentation
-    click Documentation href "../Documentation"
-
-        
-      RiskTaxonomy : hasLicense
+      Impact : isDetectedBy
         
           
     
     
-    RiskTaxonomy --> "0..1" License : hasLicense
-    click License href "../License"
+    Impact --> "*" RiskControl : isDetectedBy
+    click RiskControl href "../RiskControl"
 
         
-      RiskTaxonomy : id
+      Impact : name
         
-      RiskTaxonomy : name
-        
-      RiskTaxonomy : url
-        
-      RiskTaxonomy : version
+      Impact : url
         
       
 ```
@@ -64,7 +50,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ## Inheritance
 * [Entity](Entity.md)
-    * **RiskTaxonomy**
+    * **Impact** [ [RiskConcept](RiskConcept.md)]
 
 
 
@@ -72,9 +58,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [version](version.md) | 0..1 <br/> [String](String.md) | The version of the entity embodied by a specified resource | direct |
-| [hasDocumentation](hasDocumentation.md) | * <br/> [Documentation](Documentation.md) | Indicates documentation associated with an entity | direct |
-| [hasLicense](hasLicense.md) | 0..1 <br/> [License](License.md) | Indicates licenses associated with a resource | direct |
+| [isDetectedBy](isDetectedBy.md) | * <br/> [RiskControl](RiskControl.md) | A relationship where a risk, risk source, consequence, or impact is detected ... | [RiskConcept](RiskConcept.md) |
 | [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
@@ -90,12 +74,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
-| [Container](Container.md) | [taxonomies](taxonomies.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskGroup](RiskGroup.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Risk](Risk.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskControl](RiskControl.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Action](Action.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskIncident](RiskIncident.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
+| [RiskIncident](RiskIncident.md) | [hasImpactOn](hasImpactOn.md) | range | [Impact](Impact.md) |
+| [RiskIncident](RiskIncident.md) | [hasImpact](hasImpact.md) | range | [Impact](Impact.md) |
 
 
 
@@ -122,8 +102,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:RiskTaxonomy |
-| native | nexus:RiskTaxonomy |
+| self | dpv:Impact |
+| native | nexus:Impact |
 
 
 
@@ -139,14 +119,12 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Impact
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
-slots:
-- version
-- hasDocumentation
-- hasLicense
+mixins:
+- RiskConcept
+class_uri: dpv:Impact
 
 ```
 </details>
@@ -155,55 +133,27 @@ slots:
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Impact
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
+mixins:
+- RiskConcept
 attributes:
-  version:
-    name: version
-    description: The version of the entity embodied by a specified resource.
+  isDetectedBy:
+    name: isDetectedBy
+    description: A relationship where a risk, risk source, consequence, or impact
+      is detected by a risk control.
     from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
     rank: 1000
-    slot_uri: schema:version
-    alias: version
-    owner: RiskTaxonomy
+    domain: RiskConcept
+    alias: isDetectedBy
+    owner: Impact
     domain_of:
-    - License
-    - RiskTaxonomy
-    range: string
-  hasDocumentation:
-    name: hasDocumentation
-    description: Indicates documentation associated with an entity.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasDocumentation
-    alias: hasDocumentation
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - Action
-    - AiEval
-    - BaseAi
-    - LargeLanguageModelFamily
-    range: Documentation
+    - RiskConcept
+    inverse: detectsRiskConcept
+    range: RiskControl
     multivalued: true
     inlined: false
-  hasLicense:
-    name: hasLicense
-    description: Indicates licenses associated with a resource
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasLicense
-    alias: hasLicense
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - AiEval
-    - BaseAi
-    range: License
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
@@ -213,7 +163,7 @@ attributes:
     slot_uri: schema:identifier
     identifier: true
     alias: id
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: string
@@ -225,7 +175,7 @@ attributes:
     rank: 1000
     slot_uri: schema:name
     alias: name
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: string
@@ -236,7 +186,7 @@ attributes:
     rank: 1000
     slot_uri: schema:description
     alias: description
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: string
@@ -247,7 +197,7 @@ attributes:
     rank: 1000
     slot_uri: schema:url
     alias: url
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: uri
@@ -258,7 +208,7 @@ attributes:
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: date
@@ -270,11 +220,12 @@ attributes:
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified
-    owner: RiskTaxonomy
+    owner: Impact
     domain_of:
     - Entity
     range: date
     required: false
+class_uri: dpv:Impact
 
 ```
 </details>

--- a/docs/ontology/IncidentConcludedclass.md
+++ b/docs/ontology/IncidentConcludedclass.md
@@ -1,0 +1,193 @@
+
+
+# Class: IncidentConcludedclass
+
+
+
+URI: [dpv:IncidentConcludedclass](https://w3c.github.io/dpv/2.1/dpv/#IncidentConcludedclass)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class IncidentConcludedclass
+    click IncidentConcludedclass href "../IncidentConcludedclass"
+      IncidentStatus <|-- IncidentConcludedclass
+        click IncidentStatus href "../IncidentStatus"
+      
+      IncidentConcludedclass : dateCreated
+        
+      IncidentConcludedclass : dateModified
+        
+      IncidentConcludedclass : description
+        
+      IncidentConcludedclass : id
+        
+      IncidentConcludedclass : name
+        
+      IncidentConcludedclass : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * [IncidentStatus](IncidentStatus.md)
+        * **IncidentConcludedclass**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dpv:IncidentConcludedclass |
+| native | nexus:IncidentConcludedclass |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: IncidentConcludedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+class_uri: dpv:IncidentConcludedclass
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: IncidentConcludedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+attributes:
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: IncidentConcludedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: dpv:IncidentConcludedclass
+
+```
+</details>

--- a/docs/ontology/IncidentHaltedclass.md
+++ b/docs/ontology/IncidentHaltedclass.md
@@ -1,0 +1,193 @@
+
+
+# Class: IncidentHaltedclass
+
+
+
+URI: [dpv:IncidentHaltedclass](https://w3c.github.io/dpv/2.1/dpv/#IncidentHaltedclass)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class IncidentHaltedclass
+    click IncidentHaltedclass href "../IncidentHaltedclass"
+      IncidentStatus <|-- IncidentHaltedclass
+        click IncidentStatus href "../IncidentStatus"
+      
+      IncidentHaltedclass : dateCreated
+        
+      IncidentHaltedclass : dateModified
+        
+      IncidentHaltedclass : description
+        
+      IncidentHaltedclass : id
+        
+      IncidentHaltedclass : name
+        
+      IncidentHaltedclass : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * [IncidentStatus](IncidentStatus.md)
+        * **IncidentHaltedclass**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dpv:IncidentHaltedclass |
+| native | nexus:IncidentHaltedclass |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: IncidentHaltedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+class_uri: dpv:IncidentHaltedclass
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: IncidentHaltedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+attributes:
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: IncidentHaltedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: dpv:IncidentHaltedclass
+
+```
+</details>

--- a/docs/ontology/IncidentMitigatedclass.md
+++ b/docs/ontology/IncidentMitigatedclass.md
@@ -1,0 +1,193 @@
+
+
+# Class: IncidentMitigatedclass
+
+
+
+URI: [dpv:IncidentMitigatedclass](https://w3c.github.io/dpv/2.1/dpv/#IncidentMitigatedclass)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class IncidentMitigatedclass
+    click IncidentMitigatedclass href "../IncidentMitigatedclass"
+      IncidentStatus <|-- IncidentMitigatedclass
+        click IncidentStatus href "../IncidentStatus"
+      
+      IncidentMitigatedclass : dateCreated
+        
+      IncidentMitigatedclass : dateModified
+        
+      IncidentMitigatedclass : description
+        
+      IncidentMitigatedclass : id
+        
+      IncidentMitigatedclass : name
+        
+      IncidentMitigatedclass : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * [IncidentStatus](IncidentStatus.md)
+        * **IncidentMitigatedclass**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dpv:IncidentMitigatedclass |
+| native | nexus:IncidentMitigatedclass |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: IncidentMitigatedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+class_uri: dpv:IncidentMitigatedclass
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: IncidentMitigatedclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+attributes:
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: IncidentMitigatedclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: dpv:IncidentMitigatedclass
+
+```
+</details>

--- a/docs/ontology/IncidentNearMissclass.md
+++ b/docs/ontology/IncidentNearMissclass.md
@@ -1,0 +1,193 @@
+
+
+# Class: IncidentNearMissclass
+
+
+
+URI: [dpv:IncidentNearMissclass](https://w3c.github.io/dpv/2.1/dpv/#IncidentNearMissclass)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class IncidentNearMissclass
+    click IncidentNearMissclass href "../IncidentNearMissclass"
+      IncidentStatus <|-- IncidentNearMissclass
+        click IncidentStatus href "../IncidentStatus"
+      
+      IncidentNearMissclass : dateCreated
+        
+      IncidentNearMissclass : dateModified
+        
+      IncidentNearMissclass : description
+        
+      IncidentNearMissclass : id
+        
+      IncidentNearMissclass : name
+        
+      IncidentNearMissclass : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * [IncidentStatus](IncidentStatus.md)
+        * **IncidentNearMissclass**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dpv:IncidentNearMissclass |
+| native | nexus:IncidentNearMissclass |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: IncidentNearMissclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+class_uri: dpv:IncidentNearMissclass
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: IncidentNearMissclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+attributes:
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: IncidentNearMissclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: dpv:IncidentNearMissclass
+
+```
+</details>

--- a/docs/ontology/IncidentOngoingclass.md
+++ b/docs/ontology/IncidentOngoingclass.md
@@ -1,0 +1,193 @@
+
+
+# Class: IncidentOngoingclass
+
+
+
+URI: [dpv:IncidentOngoingclass](https://w3c.github.io/dpv/2.1/dpv/#IncidentOngoingclass)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class IncidentOngoingclass
+    click IncidentOngoingclass href "../IncidentOngoingclass"
+      IncidentStatus <|-- IncidentOngoingclass
+        click IncidentStatus href "../IncidentStatus"
+      
+      IncidentOngoingclass : dateCreated
+        
+      IncidentOngoingclass : dateModified
+        
+      IncidentOngoingclass : description
+        
+      IncidentOngoingclass : id
+        
+      IncidentOngoingclass : name
+        
+      IncidentOngoingclass : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * [IncidentStatus](IncidentStatus.md)
+        * **IncidentOngoingclass**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dpv:IncidentOngoingclass |
+| native | nexus:IncidentOngoingclass |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: IncidentOngoingclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+class_uri: dpv:IncidentOngoingclass
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: IncidentOngoingclass
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: IncidentStatus
+attributes:
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: IncidentOngoingclass
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: dpv:IncidentOngoingclass
+
+```
+</details>

--- a/docs/ontology/IncidentStatus.md
+++ b/docs/ontology/IncidentStatus.md
@@ -1,15 +1,10 @@
 
 
-# Class: RiskTaxonomy
-
-
-_A taxonomy of AI system related risks_
+# Class: IncidentStatus
 
 
 
-
-
-URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
+URI: [dpv:IncidentStatus](https://w3c.github.io/dpv/2.1/dpv/#IncidentStatus)
 
 
 
@@ -18,42 +13,35 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ```mermaid
  classDiagram
-    class RiskTaxonomy
-    click RiskTaxonomy href "../RiskTaxonomy"
-      Entity <|-- RiskTaxonomy
+    class IncidentStatus
+    click IncidentStatus href "../IncidentStatus"
+      Entity <|-- IncidentStatus
         click Entity href "../Entity"
       
-      RiskTaxonomy : dateCreated
-        
-      RiskTaxonomy : dateModified
-        
-      RiskTaxonomy : description
-        
-      RiskTaxonomy : hasDocumentation
-        
-          
-    
-    
-    RiskTaxonomy --> "*" Documentation : hasDocumentation
-    click Documentation href "../Documentation"
 
+      IncidentStatus <|-- IncidentConcludedclass
+        click IncidentConcludedclass href "../IncidentConcludedclass"
+      IncidentStatus <|-- IncidentHaltedclass
+        click IncidentHaltedclass href "../IncidentHaltedclass"
+      IncidentStatus <|-- IncidentMitigatedclass
+        click IncidentMitigatedclass href "../IncidentMitigatedclass"
+      IncidentStatus <|-- IncidentNearMissclass
+        click IncidentNearMissclass href "../IncidentNearMissclass"
+      IncidentStatus <|-- IncidentOngoingclass
+        click IncidentOngoingclass href "../IncidentOngoingclass"
+      
+      
+      IncidentStatus : dateCreated
         
-      RiskTaxonomy : hasLicense
+      IncidentStatus : dateModified
         
-          
-    
-    
-    RiskTaxonomy --> "0..1" License : hasLicense
-    click License href "../License"
-
+      IncidentStatus : description
         
-      RiskTaxonomy : id
+      IncidentStatus : id
         
-      RiskTaxonomy : name
+      IncidentStatus : name
         
-      RiskTaxonomy : url
-        
-      RiskTaxonomy : version
+      IncidentStatus : url
         
       
 ```
@@ -64,7 +52,12 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ## Inheritance
 * [Entity](Entity.md)
-    * **RiskTaxonomy**
+    * **IncidentStatus**
+        * [IncidentConcludedclass](IncidentConcludedclass.md)
+        * [IncidentHaltedclass](IncidentHaltedclass.md)
+        * [IncidentMitigatedclass](IncidentMitigatedclass.md)
+        * [IncidentNearMissclass](IncidentNearMissclass.md)
+        * [IncidentOngoingclass](IncidentOngoingclass.md)
 
 
 
@@ -72,9 +65,6 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [version](version.md) | 0..1 <br/> [String](String.md) | The version of the entity embodied by a specified resource | direct |
-| [hasDocumentation](hasDocumentation.md) | * <br/> [Documentation](Documentation.md) | Indicates documentation associated with an entity | direct |
-| [hasLicense](hasLicense.md) | 0..1 <br/> [License](License.md) | Indicates licenses associated with a resource | direct |
 | [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
@@ -90,12 +80,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
-| [Container](Container.md) | [taxonomies](taxonomies.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskGroup](RiskGroup.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Risk](Risk.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskControl](RiskControl.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Action](Action.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskIncident](RiskIncident.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
+| [RiskIncident](RiskIncident.md) | [hasStatus](hasStatus.md) | range | [IncidentStatus](IncidentStatus.md) |
 
 
 
@@ -122,8 +107,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:RiskTaxonomy |
-| native | nexus:RiskTaxonomy |
+| self | dpv:IncidentStatus |
+| native | nexus:IncidentStatus |
 
 
 
@@ -139,14 +124,10 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: IncidentStatus
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
-slots:
-- version
-- hasDocumentation
-- hasLicense
+class_uri: dpv:IncidentStatus
 
 ```
 </details>
@@ -155,55 +136,10 @@ slots:
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: IncidentStatus
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
-  version:
-    name: version
-    description: The version of the entity embodied by a specified resource.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: schema:version
-    alias: version
-    owner: RiskTaxonomy
-    domain_of:
-    - License
-    - RiskTaxonomy
-    range: string
-  hasDocumentation:
-    name: hasDocumentation
-    description: Indicates documentation associated with an entity.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasDocumentation
-    alias: hasDocumentation
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - Action
-    - AiEval
-    - BaseAi
-    - LargeLanguageModelFamily
-    range: Documentation
-    multivalued: true
-    inlined: false
-  hasLicense:
-    name: hasLicense
-    description: Indicates licenses associated with a resource
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasLicense
-    alias: hasLicense
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - AiEval
-    - BaseAi
-    range: License
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
@@ -213,7 +149,7 @@ attributes:
     slot_uri: schema:identifier
     identifier: true
     alias: id
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: string
@@ -225,7 +161,7 @@ attributes:
     rank: 1000
     slot_uri: schema:name
     alias: name
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: string
@@ -236,7 +172,7 @@ attributes:
     rank: 1000
     slot_uri: schema:description
     alias: description
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: string
@@ -247,7 +183,7 @@ attributes:
     rank: 1000
     slot_uri: schema:url
     alias: url
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: uri
@@ -258,7 +194,7 @@ attributes:
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: date
@@ -270,11 +206,12 @@ attributes:
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified
-    owner: RiskTaxonomy
+    owner: IncidentStatus
     domain_of:
     - Entity
     range: date
     required: false
+class_uri: dpv:IncidentStatus
 
 ```
 </details>

--- a/docs/ontology/Likelihood.md
+++ b/docs/ontology/Likelihood.md
@@ -1,15 +1,10 @@
 
 
-# Class: RiskTaxonomy
-
-
-_A taxonomy of AI system related risks_
+# Class: Likelihood
 
 
 
-
-
-URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
+URI: [dpv:Likelihood](https://w3c.github.io/dpv/2.1/dpv/#Likelihood)
 
 
 
@@ -18,42 +13,22 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ```mermaid
  classDiagram
-    class RiskTaxonomy
-    click RiskTaxonomy href "../RiskTaxonomy"
-      Entity <|-- RiskTaxonomy
+    class Likelihood
+    click Likelihood href "../Likelihood"
+      Entity <|-- Likelihood
         click Entity href "../Entity"
       
-      RiskTaxonomy : dateCreated
+      Likelihood : dateCreated
         
-      RiskTaxonomy : dateModified
+      Likelihood : dateModified
         
-      RiskTaxonomy : description
+      Likelihood : description
         
-      RiskTaxonomy : hasDocumentation
+      Likelihood : id
         
-          
-    
-    
-    RiskTaxonomy --> "*" Documentation : hasDocumentation
-    click Documentation href "../Documentation"
-
+      Likelihood : name
         
-      RiskTaxonomy : hasLicense
-        
-          
-    
-    
-    RiskTaxonomy --> "0..1" License : hasLicense
-    click License href "../License"
-
-        
-      RiskTaxonomy : id
-        
-      RiskTaxonomy : name
-        
-      RiskTaxonomy : url
-        
-      RiskTaxonomy : version
+      Likelihood : url
         
       
 ```
@@ -64,7 +39,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ## Inheritance
 * [Entity](Entity.md)
-    * **RiskTaxonomy**
+    * **Likelihood**
 
 
 
@@ -72,9 +47,6 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [version](version.md) | 0..1 <br/> [String](String.md) | The version of the entity embodied by a specified resource | direct |
-| [hasDocumentation](hasDocumentation.md) | * <br/> [Documentation](Documentation.md) | Indicates documentation associated with an entity | direct |
-| [hasLicense](hasLicense.md) | 0..1 <br/> [License](License.md) | Indicates licenses associated with a resource | direct |
 | [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
@@ -90,12 +62,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
-| [Container](Container.md) | [taxonomies](taxonomies.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskGroup](RiskGroup.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Risk](Risk.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskControl](RiskControl.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Action](Action.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskIncident](RiskIncident.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
+| [RiskIncident](RiskIncident.md) | [hasLikelihood](hasLikelihood.md) | range | [Likelihood](Likelihood.md) |
 
 
 
@@ -122,8 +89,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:RiskTaxonomy |
-| native | nexus:RiskTaxonomy |
+| self | dpv:Likelihood |
+| native | nexus:Likelihood |
 
 
 
@@ -139,14 +106,10 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Likelihood
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
-slots:
-- version
-- hasDocumentation
-- hasLicense
+class_uri: dpv:Likelihood
 
 ```
 </details>
@@ -155,55 +118,10 @@ slots:
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Likelihood
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
-  version:
-    name: version
-    description: The version of the entity embodied by a specified resource.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: schema:version
-    alias: version
-    owner: RiskTaxonomy
-    domain_of:
-    - License
-    - RiskTaxonomy
-    range: string
-  hasDocumentation:
-    name: hasDocumentation
-    description: Indicates documentation associated with an entity.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasDocumentation
-    alias: hasDocumentation
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - Action
-    - AiEval
-    - BaseAi
-    - LargeLanguageModelFamily
-    range: Documentation
-    multivalued: true
-    inlined: false
-  hasLicense:
-    name: hasLicense
-    description: Indicates licenses associated with a resource
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasLicense
-    alias: hasLicense
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - AiEval
-    - BaseAi
-    range: License
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
@@ -213,7 +131,7 @@ attributes:
     slot_uri: schema:identifier
     identifier: true
     alias: id
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: string
@@ -225,7 +143,7 @@ attributes:
     rank: 1000
     slot_uri: schema:name
     alias: name
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: string
@@ -236,7 +154,7 @@ attributes:
     rank: 1000
     slot_uri: schema:description
     alias: description
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: string
@@ -247,7 +165,7 @@ attributes:
     rank: 1000
     slot_uri: schema:url
     alias: url
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: uri
@@ -258,7 +176,7 @@ attributes:
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: date
@@ -270,11 +188,12 @@ attributes:
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified
-    owner: RiskTaxonomy
+    owner: Likelihood
     domain_of:
     - Entity
     range: date
     required: false
+class_uri: dpv:Likelihood
 
 ```
 </details>

--- a/docs/ontology/Risk.md
+++ b/docs/ontology/Risk.md
@@ -197,6 +197,7 @@ URI: [airo:Risk](https://w3id.org/airo#Risk)
 | [Risk](Risk.md) | [narrowMatch](narrowMatch.md) | any_of[range] | [Risk](Risk.md) |
 | [Risk](Risk.md) | [relatedMatch](relatedMatch.md) | any_of[range] | [Risk](Risk.md) |
 | [Action](Action.md) | [hasRelatedRisk](hasRelatedRisk.md) | range | [Risk](Risk.md) |
+| [RiskIncident](RiskIncident.md) | [refersToRisk](refersToRisk.md) | range | [Risk](Risk.md) |
 | [AiEval](AiEval.md) | [hasRelatedRisk](hasRelatedRisk.md) | range | [Risk](Risk.md) |
 | [Question](Question.md) | [hasRelatedRisk](hasRelatedRisk.md) | range | [Risk](Risk.md) |
 | [Questionnaire](Questionnaire.md) | [hasRelatedRisk](hasRelatedRisk.md) | range | [Risk](Risk.md) |
@@ -403,6 +404,7 @@ attributes:
     - Risk
     - RiskControl
     - Action
+    - RiskIncident
     range: RiskTaxonomy
   isPartOf:
     name: isPartOf

--- a/docs/ontology/RiskConcept.md
+++ b/docs/ontology/RiskConcept.md
@@ -30,6 +30,10 @@ URI: [airo:RiskConcept](https://w3id.org/airo#RiskConcept)
         click Risk href "../Risk"
       RiskConcept <|-- RiskControl
         click RiskControl href "../RiskControl"
+      RiskConcept <|-- RiskIncident
+        click RiskIncident href "../RiskIncident"
+      RiskConcept <|-- Impact
+        click Impact href "../Impact"
       
       
       RiskConcept : dateCreated
@@ -93,6 +97,14 @@ URI: [airo:RiskConcept](https://w3id.org/airo#RiskConcept)
 | [RiskControl](RiskControl.md) | [detectsRiskConcept](detectsRiskConcept.md) | range | [RiskConcept](RiskConcept.md) |
 | [RiskControl](RiskControl.md) | [isDetectedBy](isDetectedBy.md) | domain | [RiskConcept](RiskConcept.md) |
 | [Action](Action.md) | [hasRelatedRisk](hasRelatedRisk.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasStatus](hasStatus.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasSeverity](hasSeverity.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasLikelihood](hasLikelihood.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasImpactOn](hasImpactOn.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasConsequence](hasConsequence.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [hasImpact](hasImpact.md) | domain | [RiskConcept](RiskConcept.md) |
+| [RiskIncident](RiskIncident.md) | [isDetectedBy](isDetectedBy.md) | domain | [RiskConcept](RiskConcept.md) |
+| [Impact](Impact.md) | [isDetectedBy](isDetectedBy.md) | domain | [RiskConcept](RiskConcept.md) |
 | [AiEval](AiEval.md) | [hasRelatedRisk](hasRelatedRisk.md) | domain | [RiskConcept](RiskConcept.md) |
 | [Question](Question.md) | [hasRelatedRisk](hasRelatedRisk.md) | domain | [RiskConcept](RiskConcept.md) |
 | [Questionnaire](Questionnaire.md) | [hasRelatedRisk](hasRelatedRisk.md) | domain | [RiskConcept](RiskConcept.md) |

--- a/docs/ontology/RiskControl.md
+++ b/docs/ontology/RiskControl.md
@@ -106,6 +106,8 @@ URI: [airo:RiskControl](https://w3id.org/airo#RiskControl)
 | [RiskConcept](RiskConcept.md) | [isDetectedBy](isDetectedBy.md) | range | [RiskControl](RiskControl.md) |
 | [RiskControl](RiskControl.md) | [detectsRiskConcept](detectsRiskConcept.md) | domain | [RiskControl](RiskControl.md) |
 | [RiskControl](RiskControl.md) | [isDetectedBy](isDetectedBy.md) | range | [RiskControl](RiskControl.md) |
+| [RiskIncident](RiskIncident.md) | [isDetectedBy](isDetectedBy.md) | range | [RiskControl](RiskControl.md) |
+| [Impact](Impact.md) | [isDetectedBy](isDetectedBy.md) | range | [RiskControl](RiskControl.md) |
 | [AiModel](AiModel.md) | [hasRiskControl](hasRiskControl.md) | range | [RiskControl](RiskControl.md) |
 | [LargeLanguageModel](LargeLanguageModel.md) | [hasRiskControl](hasRiskControl.md) | range | [RiskControl](RiskControl.md) |
 
@@ -208,6 +210,7 @@ attributes:
     - Risk
     - RiskControl
     - Action
+    - RiskIncident
     range: RiskTaxonomy
   isDetectedBy:
     name: isDetectedBy

--- a/docs/ontology/RiskGroup.md
+++ b/docs/ontology/RiskGroup.md
@@ -257,6 +257,7 @@ attributes:
     - Risk
     - RiskControl
     - Action
+    - RiskIncident
     range: RiskTaxonomy
   closeMatch:
     name: closeMatch

--- a/docs/ontology/RiskIncident.md
+++ b/docs/ontology/RiskIncident.md
@@ -1,0 +1,498 @@
+
+
+# Class: RiskIncident
+
+
+_An event occuring or occured which is a realised or materialised risk._
+
+
+
+
+
+URI: [https://w3id.org/dpv/risk#Incident](https://w3id.org/dpv/risk#Incident)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class RiskIncident
+    click RiskIncident href "../RiskIncident"
+      RiskConcept <|-- RiskIncident
+        click RiskConcept href "../RiskConcept"
+      Entity <|-- RiskIncident
+        click Entity href "../Entity"
+      
+      RiskIncident : author
+        
+      RiskIncident : dateCreated
+        
+      RiskIncident : dateModified
+        
+      RiskIncident : description
+        
+      RiskIncident : hasConsequence
+        
+          
+    
+    
+    RiskIncident --> "0..1" Consequence : hasConsequence
+    click Consequence href "../Consequence"
+
+        
+      RiskIncident : hasImpact
+        
+          
+    
+    
+    RiskIncident --> "0..1" Impact : hasImpact
+    click Impact href "../Impact"
+
+        
+      RiskIncident : hasImpactOn
+        
+          
+    
+    
+    RiskIncident --> "0..1" Impact : hasImpactOn
+    click Impact href "../Impact"
+
+        
+      RiskIncident : hasLikelihood
+        
+          
+    
+    
+    RiskIncident --> "0..1" Likelihood : hasLikelihood
+    click Likelihood href "../Likelihood"
+
+        
+      RiskIncident : hasSeverity
+        
+          
+    
+    
+    RiskIncident --> "0..1" Severity : hasSeverity
+    click Severity href "../Severity"
+
+        
+      RiskIncident : hasStatus
+        
+          
+    
+    
+    RiskIncident --> "0..1" IncidentStatus : hasStatus
+    click IncidentStatus href "../IncidentStatus"
+
+        
+      RiskIncident : hasVariant
+        
+          
+    
+    
+    RiskIncident --> "0..1" RiskIncident : hasVariant
+    click RiskIncident href "../RiskIncident"
+
+        
+      RiskIncident : id
+        
+      RiskIncident : isDefinedByTaxonomy
+        
+          
+    
+    
+    RiskIncident --> "0..1" RiskTaxonomy : isDefinedByTaxonomy
+    click RiskTaxonomy href "../RiskTaxonomy"
+
+        
+      RiskIncident : isDetectedBy
+        
+          
+    
+    
+    RiskIncident --> "*" RiskControl : isDetectedBy
+    click RiskControl href "../RiskControl"
+
+        
+      RiskIncident : name
+        
+      RiskIncident : refersToRisk
+        
+          
+    
+    
+    RiskIncident --> "*" Risk : refersToRisk
+    click Risk href "../Risk"
+
+        
+      RiskIncident : source_uri
+        
+      RiskIncident : url
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Entity](Entity.md)
+    * **RiskIncident** [ [RiskConcept](RiskConcept.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [refersToRisk](refersToRisk.md) | * <br/> [Risk](Risk.md) | Indicates the incident (subject) is a materialisation of the indicated risk (... | direct |
+| [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | 0..1 <br/> [RiskTaxonomy](RiskTaxonomy.md) | A relationship where a risk or a risk group is defined by a risk taxonomy | direct |
+| [hasStatus](hasStatus.md) | 0..1 <br/> [IncidentStatus](IncidentStatus.md) | Indicates the status of specified concept | direct |
+| [hasSeverity](hasSeverity.md) | 0..1 <br/> [Severity](Severity.md) | Indicates the severity associated with a concept | direct |
+| [hasLikelihood](hasLikelihood.md) | 0..1 <br/> [Likelihood](Likelihood.md) | The likelihood or probability or chance of something taking place or occuring | direct |
+| [hasImpactOn](hasImpactOn.md) | 0..1 <br/> [Impact](Impact.md) | Indicates impact(s) possible or arising as consequences from specified concep... | direct |
+| [hasConsequence](hasConsequence.md) | 0..1 <br/> [Consequence](Consequence.md) | Indicates consequence(s) possible or arising from specified concept | direct |
+| [hasImpact](hasImpact.md) | 0..1 <br/> [Impact](Impact.md) | Indicates impact(s) possible or arising as consequences from specified concep... | direct |
+| [hasVariant](hasVariant.md) | 0..1 <br/> [RiskIncident](RiskIncident.md) | Indicates an incident that shares the same causative factors, produces simila... | direct |
+| [author](author.md) | 0..1 <br/> [String](String.md) | The author or authors of the incident report | direct |
+| [source_uri](source_uri.md) | 0..1 <br/> [String](String.md) | The uri of the incident | direct |
+| [isDetectedBy](isDetectedBy.md) | * <br/> [RiskControl](RiskControl.md) | A relationship where a risk, risk source, consequence, or impact is detected ... | [RiskConcept](RiskConcept.md) |
+| [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
+| [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
+| [url](url.md) | 0..1 <br/> [Uri](Uri.md) | An optional URL associated with this instance | [Entity](Entity.md) |
+| [dateCreated](dateCreated.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was created | [Entity](Entity.md) |
+| [dateModified](dateModified.md) | 0..1 <br/> [Date](Date.md) | The date on which the entity was most recently modified | [Entity](Entity.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Container](Container.md) | [riskincidents](riskincidents.md) | range | [RiskIncident](RiskIncident.md) |
+| [RiskIncident](RiskIncident.md) | [refersToRisk](refersToRisk.md) | domain | [RiskIncident](RiskIncident.md) |
+| [RiskIncident](RiskIncident.md) | [hasVariant](hasVariant.md) | domain | [RiskIncident](RiskIncident.md) |
+| [RiskIncident](RiskIncident.md) | [hasVariant](hasVariant.md) | range | [RiskIncident](RiskIncident.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/dpv/risk#Incident |
+| native | nexus:RiskIncident |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: RiskIncident
+description: An event occuring or occured which is a realised or materialised risk.
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: Entity
+mixins:
+- RiskConcept
+slots:
+- refersToRisk
+- isDefinedByTaxonomy
+- hasStatus
+- hasSeverity
+- hasLikelihood
+- hasImpactOn
+- hasConsequence
+- hasImpact
+- hasVariant
+attributes:
+  author:
+    name: author
+    description: The author or authors of the incident report
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
+    rank: 1000
+    domain_of:
+    - RiskIncident
+  source_uri:
+    name: source_uri
+    description: The uri of the incident
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
+    rank: 1000
+    domain_of:
+    - RiskIncident
+class_uri: https://w3id.org/dpv/risk#Incident
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: RiskIncident
+description: An event occuring or occured which is a realised or materialised risk.
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+is_a: Entity
+mixins:
+- RiskConcept
+attributes:
+  author:
+    name: author
+    description: The author or authors of the incident report
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
+    rank: 1000
+    alias: author
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: string
+  source_uri:
+    name: source_uri
+    description: The uri of the incident
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk
+    rank: 1000
+    alias: source_uri
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: string
+  refersToRisk:
+    name: refersToRisk
+    description: Indicates the incident (subject) is a materialisation of the indicated
+      risk (object)
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    exact_mappings:
+    - dpv:refersToRisk
+    rank: 1000
+    domain: RiskIncident
+    alias: refersToRisk
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Risk
+    multivalued: true
+    inlined: false
+  isDefinedByTaxonomy:
+    name: isDefinedByTaxonomy
+    description: A relationship where a risk or a risk group is defined by a risk
+      taxonomy
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:isPartOf
+    alias: isDefinedByTaxonomy
+    owner: RiskIncident
+    domain_of:
+    - RiskGroup
+    - Risk
+    - RiskControl
+    - Action
+    - RiskIncident
+    range: RiskTaxonomy
+  hasStatus:
+    name: hasStatus
+    description: Indicates the status of specified concept
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskConcept
+    alias: hasStatus
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: IncidentStatus
+  hasSeverity:
+    name: hasSeverity
+    description: Indicates the severity associated with a concept
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskConcept
+    alias: hasSeverity
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Severity
+  hasLikelihood:
+    name: hasLikelihood
+    description: The likelihood or probability or chance of something taking place
+      or occuring
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskConcept
+    alias: hasLikelihood
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Likelihood
+  hasImpactOn:
+    name: hasImpactOn
+    description: Indicates impact(s) possible or arising as consequences from specified
+      concept
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    broad_mappings:
+    - dpv:hasConsequenceOn
+    rank: 1000
+    domain: RiskConcept
+    alias: hasImpactOn
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Impact
+  hasConsequence:
+    name: hasConsequence
+    description: Indicates consequence(s) possible or arising from specified concept
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskConcept
+    alias: hasConsequence
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Consequence
+  hasImpact:
+    name: hasImpact
+    description: Indicates impact(s) possible or arising as consequences from specified
+      concept
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    broad_mappings:
+    - dpv:hasConsequence
+    rank: 1000
+    domain: RiskConcept
+    alias: hasImpact
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: Impact
+  hasVariant:
+    name: hasVariant
+    description: 'Indicates an incident that shares the same causative factors, produces
+      similar harms, and involves the same intelligent systems as a known AI incident. '
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskIncident
+    alias: hasVariant
+    owner: RiskIncident
+    domain_of:
+    - RiskIncident
+    range: RiskIncident
+  isDetectedBy:
+    name: isDetectedBy
+    description: A relationship where a risk, risk source, consequence, or impact
+      is detected by a risk control.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    domain: RiskConcept
+    alias: isDetectedBy
+    owner: RiskIncident
+    domain_of:
+    - RiskConcept
+    inverse: detectsRiskConcept
+    range: RiskControl
+    multivalued: true
+    inlined: false
+  id:
+    name: id
+    description: A unique identifier to this instance of the model element. Example
+      identifiers include UUID, URI, URN, etc.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:identifier
+    identifier: true
+    alias: id
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: string
+    required: true
+  name:
+    name: name
+    description: A text name of this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: string
+  description:
+    name: description
+    description: The description of an entity
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: string
+  url:
+    name: url
+    description: An optional URL associated with this instance.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:url
+    alias: url
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: uri
+  dateCreated:
+    name: dateCreated
+    description: The date on which the entity was created.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateCreated
+    alias: dateCreated
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: date
+    required: false
+  dateModified:
+    name: dateModified
+    description: The date on which the entity was most recently modified.
+    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+    rank: 1000
+    slot_uri: schema:dateModified
+    alias: dateModified
+    owner: RiskIncident
+    domain_of:
+    - Entity
+    range: date
+    required: false
+class_uri: https://w3id.org/dpv/risk#Incident
+
+```
+</details>

--- a/docs/ontology/Severity.md
+++ b/docs/ontology/Severity.md
@@ -1,15 +1,10 @@
 
 
-# Class: RiskTaxonomy
-
-
-_A taxonomy of AI system related risks_
+# Class: Severity
 
 
 
-
-
-URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTaxonomy)
+URI: [dpv:Severity](https://w3c.github.io/dpv/2.1/dpv/#Severity)
 
 
 
@@ -18,42 +13,22 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ```mermaid
  classDiagram
-    class RiskTaxonomy
-    click RiskTaxonomy href "../RiskTaxonomy"
-      Entity <|-- RiskTaxonomy
+    class Severity
+    click Severity href "../Severity"
+      Entity <|-- Severity
         click Entity href "../Entity"
       
-      RiskTaxonomy : dateCreated
+      Severity : dateCreated
         
-      RiskTaxonomy : dateModified
+      Severity : dateModified
         
-      RiskTaxonomy : description
+      Severity : description
         
-      RiskTaxonomy : hasDocumentation
+      Severity : id
         
-          
-    
-    
-    RiskTaxonomy --> "*" Documentation : hasDocumentation
-    click Documentation href "../Documentation"
-
+      Severity : name
         
-      RiskTaxonomy : hasLicense
-        
-          
-    
-    
-    RiskTaxonomy --> "0..1" License : hasLicense
-    click License href "../License"
-
-        
-      RiskTaxonomy : id
-        
-      RiskTaxonomy : name
-        
-      RiskTaxonomy : url
-        
-      RiskTaxonomy : version
+      Severity : url
         
       
 ```
@@ -64,7 +39,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 ## Inheritance
 * [Entity](Entity.md)
-    * **RiskTaxonomy**
+    * **Severity**
 
 
 
@@ -72,9 +47,6 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [version](version.md) | 0..1 <br/> [String](String.md) | The version of the entity embodied by a specified resource | direct |
-| [hasDocumentation](hasDocumentation.md) | * <br/> [Documentation](Documentation.md) | Indicates documentation associated with an entity | direct |
-| [hasLicense](hasLicense.md) | 0..1 <br/> [License](License.md) | Indicates licenses associated with a resource | direct |
 | [id](id.md) | 1 <br/> [String](String.md) | A unique identifier to this instance of the model element | [Entity](Entity.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | A text name of this instance | [Entity](Entity.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | The description of an entity | [Entity](Entity.md) |
@@ -90,12 +62,7 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
-| [Container](Container.md) | [taxonomies](taxonomies.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskGroup](RiskGroup.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Risk](Risk.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskControl](RiskControl.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [Action](Action.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
-| [RiskIncident](RiskIncident.md) | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | range | [RiskTaxonomy](RiskTaxonomy.md) |
+| [RiskIncident](RiskIncident.md) | [hasSeverity](hasSeverity.md) | range | [Severity](Severity.md) |
 
 
 
@@ -122,8 +89,8 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:RiskTaxonomy |
-| native | nexus:RiskTaxonomy |
+| self | dpv:Severity |
+| native | nexus:Severity |
 
 
 
@@ -139,14 +106,10 @@ URI: [nexus:RiskTaxonomy](https://ibm.github.io/risk-atlas-nexus/ontology/RiskTa
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Severity
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
-slots:
-- version
-- hasDocumentation
-- hasLicense
+class_uri: dpv:Severity
 
 ```
 </details>
@@ -155,55 +118,10 @@ slots:
 
 <details>
 ```yaml
-name: RiskTaxonomy
-description: A taxonomy of AI system related risks
+name: Severity
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 is_a: Entity
 attributes:
-  version:
-    name: version
-    description: The version of the entity embodied by a specified resource.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: schema:version
-    alias: version
-    owner: RiskTaxonomy
-    domain_of:
-    - License
-    - RiskTaxonomy
-    range: string
-  hasDocumentation:
-    name: hasDocumentation
-    description: Indicates documentation associated with an entity.
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasDocumentation
-    alias: hasDocumentation
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - Action
-    - AiEval
-    - BaseAi
-    - LargeLanguageModelFamily
-    range: Documentation
-    multivalued: true
-    inlined: false
-  hasLicense:
-    name: hasLicense
-    description: Indicates licenses associated with a resource
-    from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
-    rank: 1000
-    slot_uri: airo:hasLicense
-    alias: hasLicense
-    owner: RiskTaxonomy
-    domain_of:
-    - Dataset
-    - RiskTaxonomy
-    - AiEval
-    - BaseAi
-    range: License
   id:
     name: id
     description: A unique identifier to this instance of the model element. Example
@@ -213,7 +131,7 @@ attributes:
     slot_uri: schema:identifier
     identifier: true
     alias: id
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: string
@@ -225,7 +143,7 @@ attributes:
     rank: 1000
     slot_uri: schema:name
     alias: name
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: string
@@ -236,7 +154,7 @@ attributes:
     rank: 1000
     slot_uri: schema:description
     alias: description
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: string
@@ -247,7 +165,7 @@ attributes:
     rank: 1000
     slot_uri: schema:url
     alias: url
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: uri
@@ -258,7 +176,7 @@ attributes:
     rank: 1000
     slot_uri: schema:dateCreated
     alias: dateCreated
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: date
@@ -270,11 +188,12 @@ attributes:
     rank: 1000
     slot_uri: schema:dateModified
     alias: dateModified
-    owner: RiskTaxonomy
+    owner: Severity
     domain_of:
     - Entity
     range: date
     required: false
+class_uri: dpv:Severity
 
 ```
 </details>

--- a/docs/ontology/author.md
+++ b/docs/ontology/author.md
@@ -1,15 +1,15 @@
 
 
-# Slot: value
+# Slot: author
 
 
-_Some numeric or string value_
+_The author or authors of the incident report_
 
 
 
 
 
-URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
+URI: [nexus:author](https://ibm.github.io/risk-atlas-nexus/ontology/author)
 
 
 
@@ -23,8 +23,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 
 
 
@@ -35,8 +34,6 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 ## Properties
 
 * Range: [String](String.md)
-
-* Required: True
 
 
 
@@ -62,8 +59,8 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:value |
-| native | nexus:value |
+| self | nexus:author |
+| native | nexus:author |
 
 
 
@@ -72,15 +69,15 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 <details>
 ```yaml
-name: value
-description: Some numeric or string value
+name: author
+description: The author or authors of the incident report
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
-alias: value
+alias: author
+owner: RiskIncident
 domain_of:
-- Fact
+- RiskIncident
 range: string
-required: true
 
 ```
 </details>

--- a/docs/ontology/bestValue.md
+++ b/docs/ontology/bestValue.md
@@ -23,9 +23,9 @@ URI: [nexus:bestValue](https://ibm.github.io/risk-atlas-nexus/ontology/bestValue
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 
 

--- a/docs/ontology/dateCreated.md
+++ b/docs/ontology/dateCreated.md
@@ -23,34 +23,45 @@ URI: [schema:dateCreated](http://schema.org/dateCreated)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/dateModified.md
+++ b/docs/ontology/dateModified.md
@@ -23,34 +23,45 @@ URI: [schema:dateModified](http://schema.org/dateModified)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/description.md
+++ b/docs/ontology/description.md
@@ -23,34 +23,45 @@ URI: [schema:description](http://schema.org/description)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/evidence.md
+++ b/docs/ontology/evidence.md
@@ -23,8 +23,8 @@ URI: [nexus:evidence](https://ibm.github.io/risk-atlas-nexus/ontology/evidence)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
 
 
 

--- a/docs/ontology/grants_license.md
+++ b/docs/ontology/grants_license.md
@@ -23,9 +23,9 @@ URI: [nexus:grants_license](https://ibm.github.io/risk-atlas-nexus/ontology/gran
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
 | [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
 
 
 

--- a/docs/ontology/hasConsequence.md
+++ b/docs/ontology/hasConsequence.md
@@ -1,0 +1,83 @@
+
+
+# Slot: hasConsequence
+
+
+_Indicates consequence(s) possible or arising from specified concept_
+
+
+
+
+
+URI: [nexus:hasConsequence](https://ibm.github.io/risk-atlas-nexus/ontology/hasConsequence)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Consequence](Consequence.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:hasConsequence |
+| native | nexus:hasConsequence |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: hasConsequence
+description: Indicates consequence(s) possible or arising from specified concept
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+rank: 1000
+domain: RiskConcept
+alias: hasConsequence
+domain_of:
+- RiskIncident
+range: Consequence
+
+```
+</details>

--- a/docs/ontology/hasDataset.md
+++ b/docs/ontology/hasDataset.md
@@ -23,9 +23,9 @@ URI: [nexus:hasDataset](https://ibm.github.io/risk-atlas-nexus/ontology/hasDatas
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 
 

--- a/docs/ontology/hasDocumentation.md
+++ b/docs/ontology/hasDocumentation.md
@@ -23,18 +23,18 @@ URI: [airo:hasDocumentation](https://w3id.org/airo#hasDocumentation)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [Action](Action.md) | Action to remediate a risk |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 
 

--- a/docs/ontology/hasImpact.md
+++ b/docs/ontology/hasImpact.md
@@ -1,0 +1,87 @@
+
+
+# Slot: hasImpact
+
+
+_Indicates impact(s) possible or arising as consequences from specified concept_
+
+
+
+
+
+URI: [nexus:hasImpact](https://ibm.github.io/risk-atlas-nexus/ontology/hasImpact)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Impact](Impact.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:hasImpact |
+| native | nexus:hasImpact |
+| broad | dpv:hasConsequence |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: hasImpact
+description: Indicates impact(s) possible or arising as consequences from specified
+  concept
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+broad_mappings:
+- dpv:hasConsequence
+rank: 1000
+domain: RiskConcept
+alias: hasImpact
+domain_of:
+- RiskIncident
+range: Impact
+
+```
+</details>

--- a/docs/ontology/hasImpactOn.md
+++ b/docs/ontology/hasImpactOn.md
@@ -1,0 +1,87 @@
+
+
+# Slot: hasImpactOn
+
+
+_Indicates impact(s) possible or arising as consequences from specified concept_
+
+
+
+
+
+URI: [nexus:hasImpactOn](https://ibm.github.io/risk-atlas-nexus/ontology/hasImpactOn)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Impact](Impact.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:hasImpactOn |
+| native | nexus:hasImpactOn |
+| broad | dpv:hasConsequenceOn |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: hasImpactOn
+description: Indicates impact(s) possible or arising as consequences from specified
+  concept
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+broad_mappings:
+- dpv:hasConsequenceOn
+rank: 1000
+domain: RiskConcept
+alias: hasImpactOn
+domain_of:
+- RiskIncident
+range: Impact
+
+```
+</details>

--- a/docs/ontology/hasLicense.md
+++ b/docs/ontology/hasLicense.md
@@ -23,16 +23,16 @@ URI: [airo:hasLicense](https://w3id.org/airo#hasLicense)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
 | [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 
 

--- a/docs/ontology/hasLikelihood.md
+++ b/docs/ontology/hasLikelihood.md
@@ -1,0 +1,84 @@
+
+
+# Slot: hasLikelihood
+
+
+_The likelihood or probability or chance of something taking place or occuring_
+
+
+
+
+
+URI: [nexus:hasLikelihood](https://ibm.github.io/risk-atlas-nexus/ontology/hasLikelihood)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Likelihood](Likelihood.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:hasLikelihood |
+| native | nexus:hasLikelihood |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: hasLikelihood
+description: The likelihood or probability or chance of something taking place or
+  occuring
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+rank: 1000
+domain: RiskConcept
+alias: hasLikelihood
+domain_of:
+- RiskIncident
+range: Likelihood
+
+```
+</details>

--- a/docs/ontology/hasModelCard.md
+++ b/docs/ontology/hasModelCard.md
@@ -23,11 +23,11 @@ URI: [nexus:hasModelCard](https://ibm.github.io/risk-atlas-nexus/ontology/hasMod
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
 
 
 

--- a/docs/ontology/hasRelatedRisk.md
+++ b/docs/ontology/hasRelatedRisk.md
@@ -23,9 +23,9 @@ URI: [nexus:hasRelatedRisk](https://ibm.github.io/risk-atlas-nexus/ontology/hasR
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
 | [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 

--- a/docs/ontology/hasSeverity.md
+++ b/docs/ontology/hasSeverity.md
@@ -1,15 +1,15 @@
 
 
-# Slot: value
+# Slot: hasSeverity
 
 
-_Some numeric or string value_
+_Indicates the severity associated with a concept_
 
 
 
 
 
-URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
+URI: [nexus:hasSeverity](https://ibm.github.io/risk-atlas-nexus/ontology/hasSeverity)
 
 
 
@@ -23,8 +23,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 
 
 
@@ -34,9 +33,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 ## Properties
 
-* Range: [String](String.md)
-
-* Required: True
+* Range: [Severity](Severity.md)
 
 
 
@@ -62,8 +59,8 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:value |
-| native | nexus:value |
+| self | nexus:hasSeverity |
+| native | nexus:hasSeverity |
 
 
 
@@ -72,15 +69,15 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 <details>
 ```yaml
-name: value
-description: Some numeric or string value
+name: hasSeverity
+description: Indicates the severity associated with a concept
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
-alias: value
+domain: RiskConcept
+alias: hasSeverity
 domain_of:
-- Fact
-range: string
-required: true
+- RiskIncident
+range: Severity
 
 ```
 </details>

--- a/docs/ontology/hasStatus.md
+++ b/docs/ontology/hasStatus.md
@@ -1,15 +1,15 @@
 
 
-# Slot: value
+# Slot: hasStatus
 
 
-_Some numeric or string value_
+_Indicates the status of specified concept_
 
 
 
 
 
-URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
+URI: [nexus:hasStatus](https://ibm.github.io/risk-atlas-nexus/ontology/hasStatus)
 
 
 
@@ -23,8 +23,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 
 
 
@@ -34,9 +33,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 ## Properties
 
-* Range: [String](String.md)
-
-* Required: True
+* Range: [IncidentStatus](IncidentStatus.md)
 
 
 
@@ -62,8 +59,8 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:value |
-| native | nexus:value |
+| self | nexus:hasStatus |
+| native | nexus:hasStatus |
 
 
 
@@ -72,15 +69,15 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 <details>
 ```yaml
-name: value
-description: Some numeric or string value
+name: hasStatus
+description: Indicates the status of specified concept
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
-alias: value
+domain: RiskConcept
+alias: hasStatus
 domain_of:
-- Fact
-range: string
-required: true
+- RiskIncident
+range: IncidentStatus
 
 ```
 </details>

--- a/docs/ontology/hasUnitxtCard.md
+++ b/docs/ontology/hasUnitxtCard.md
@@ -23,9 +23,9 @@ URI: [schema:url](http://schema.org/url)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 | [Question](Question.md) | An evaluation where a question has to be answered |  no  |
 | [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
 
 
 

--- a/docs/ontology/hasVariant.md
+++ b/docs/ontology/hasVariant.md
@@ -1,0 +1,84 @@
+
+
+# Slot: hasVariant
+
+
+_Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident. _
+
+
+
+
+
+URI: [nexus:hasVariant](https://ibm.github.io/risk-atlas-nexus/ontology/hasVariant)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [RiskIncident](RiskIncident.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:hasVariant |
+| native | nexus:hasVariant |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: hasVariant
+description: 'Indicates an incident that shares the same causative factors, produces
+  similar harms, and involves the same intelligent systems as a known AI incident. '
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+rank: 1000
+domain: RiskIncident
+alias: hasVariant
+domain_of:
+- RiskIncident
+range: RiskIncident
+
+```
+</details>

--- a/docs/ontology/id.md
+++ b/docs/ontology/id.md
@@ -23,34 +23,45 @@ URI: [schema:identifier](http://schema.org/identifier)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/index.md
+++ b/docs/ontology/index.md
@@ -29,10 +29,19 @@ Name: ai-risk-ontology
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities. ChatGPT is an example of an AI system which deploys multiple GPT AI models. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is capable of autonomously performing tasks on behalf of a user or another system by designing its workflow and utilizing available tools. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Consequence](Consequence.md) | None |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Impact](Impact.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentStatus](IncidentStatus.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentConcludedclass](IncidentConcludedclass.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentHaltedclass](IncidentHaltedclass.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentMitigatedclass](IncidentMitigatedclass.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentNearMissclass](IncidentNearMissclass.md) | None |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[IncidentOngoingclass](IncidentOngoingclass.md) | None |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the same AI systems provider and are built around the same architecture, but differ e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite models. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[License](License.md) | The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Likelihood](Likelihood.md) | None |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Modality](Modality.md) | A modality supported by an Ai component. Examples include text, image, video. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, consortium, government, etc. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office) |
@@ -41,7 +50,9 @@ Name: ai-risk-ontology
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Severity](Severity.md) | None |
 | [Fact](Fact.md) | A fact about something, for example the result of a measurement. In addition to the value, evidence is provided. |
 
 
@@ -55,6 +66,7 @@ Name: ai-risk-ontology
 | [aimodels](aimodels.md) | A list of AI models |
 | [aitasks](aitasks.md) | A list of AI tasks |
 | [architecture](architecture.md) | A description of the architecture of an AI such as 'Decoder-only' |
+| [author](author.md) | The author or authors of the incident report |
 | [bestValue](bestValue.md) | Annotation of the best possible result of the evaluation |
 | [broadMatch](broadMatch.md) | The property is used to state a hierarchical mapping link between two concept... |
 | [carbon_emitted](carbon_emitted.md) | The number of tons of carbon dioxide equivalent that are emitted during train... |
@@ -75,21 +87,28 @@ Name: ai-risk-ontology
 | [gpu_hours](gpu_hours.md) | GPU consumption in terms of hours |
 | [grants_license](grants_license.md) | A relationship from a granting entity such as an Organization to a License in... |
 | [hasAiActorTask](hasAiActorTask.md) | Pertinent AI Actor Tasks for each subcategory |
+| [hasConsequence](hasConsequence.md) | Indicates consequence(s) possible or arising from specified concept |
 | [hasDataset](hasDataset.md) | A relationship to datasets that are used |
 | [hasDocumentation](hasDocumentation.md) | Indicates documentation associated with an entity |
 | [hasEuAiSystemType](hasEuAiSystemType.md) | The type of system as defined by the EU AI Act |
 | [hasEuRiskCategory](hasEuRiskCategory.md) | The risk category of an AI system as defined by the EU AI Act |
 | [hasEvaluation](hasEvaluation.md) | A relationship indicating that an entity has an AI evaluation result |
+| [hasImpact](hasImpact.md) | Indicates impact(s) possible or arising as consequences from specified concep... |
+| [hasImpactOn](hasImpactOn.md) | Indicates impact(s) possible or arising as consequences from specified concep... |
 | [hasInputModality](hasInputModality.md) | A relationship indicating the input modalities supported by an AI component |
 | [hasLicense](hasLicense.md) | Indicates licenses associated with a resource |
+| [hasLikelihood](hasLikelihood.md) | The likelihood or probability or chance of something taking place or occuring |
 | [hasModelCard](hasModelCard.md) | A relationship to model card references |
 | [hasOutputModality](hasOutputModality.md) | A relationship indicating the output modalities supported by an AI component |
 | [hasPart](hasPart.md) | A relationship where an entity has another entity |
 | [hasRelatedAction](hasRelatedAction.md) | A relationship where an entity relates to an action |
 | [hasRelatedRisk](hasRelatedRisk.md) | A relationship where an entity relates to a risk |
 | [hasRiskControl](hasRiskControl.md) | Indicates the control measures associated with a system or component to modif... |
+| [hasSeverity](hasSeverity.md) | Indicates the severity associated with a concept |
+| [hasStatus](hasStatus.md) | Indicates the status of specified concept |
 | [hasTrainingData](hasTrainingData.md) | A relationship indicating the datasets an AI model was trained on |
 | [hasUnitxtCard](hasUnitxtCard.md) | A relationship to a Unitxt card defining the risk evaluation |
+| [hasVariant](hasVariant.md) | Indicates an incident that shares the same causative factors, produces simila... |
 | [id](id.md) | A unique identifier to this instance of the model element |
 | [isComposedOf](isComposedOf.md) | Relationship indicating the some entity is composed of other entities (includ... |
 | [isDefinedByTaxonomy](isDefinedByTaxonomy.md) | A relationship where a risk or a risk group is defined by a risk taxonomy |
@@ -112,10 +131,13 @@ Name: ai-risk-ontology
 | [power_consumption_w](power_consumption_w.md) | power consumption in Watts |
 | [producer](producer.md) | A relationship to the Organization instance which produces this instance |
 | [provider](provider.md) | A relationship to the Organization instance that provides this instance |
+| [refersToRisk](refersToRisk.md) | Indicates the incident (subject) is a materialisation of the indicated risk (... |
 | [relatedMatch](relatedMatch.md) | The property skos:relatedMatch is used to state an associative mapping link b... |
 | [riskcontrols](riskcontrols.md) | A list of AI risk controls |
 | [riskgroups](riskgroups.md) | A list of AI risk groups |
+| [riskincidents](riskincidents.md) | A list of AI risk incidents |
 | [risks](risks.md) | A list of AI risks |
+| [source_uri](source_uri.md) | The uri of the incident |
 | [supported_languages](supported_languages.md) | A list of languages, expressed as ISO two letter codes |
 | [tag](tag.md) | A shost version of the name |
 | [taxonomies](taxonomies.md) | A list of AI risk taxonomies |

--- a/docs/ontology/isDefinedByTaxonomy.md
+++ b/docs/ontology/isDefinedByTaxonomy.md
@@ -23,9 +23,10 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
+| [Action](Action.md) | Action to remediate a risk |  no  |
 | [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
 | [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
 
 
@@ -83,6 +84,7 @@ domain_of:
 - Risk
 - RiskControl
 - Action
+- RiskIncident
 range: RiskTaxonomy
 
 ```

--- a/docs/ontology/isDetectedBy.md
+++ b/docs/ontology/isDetectedBy.md
@@ -23,10 +23,12 @@ URI: [nexus:isDetectedBy](https://ibm.github.io/risk-atlas-nexus/ontology/isDete
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 | [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
 | [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/isPartOf.md
+++ b/docs/ontology/isPartOf.md
@@ -23,8 +23,8 @@ URI: [schema:isPartOf](http://schema.org/isPartOf)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  yes  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  yes  |
+| [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  yes  |
 
 
 

--- a/docs/ontology/isProvidedBy.md
+++ b/docs/ontology/isProvidedBy.md
@@ -23,11 +23,11 @@ URI: [airo:isProvidedBy](https://w3id.org/airo#isProvidedBy)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  yes  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  yes  |
 
 
 

--- a/docs/ontology/name.md
+++ b/docs/ontology/name.md
@@ -23,34 +23,45 @@ URI: [schema:name](http://schema.org/name)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/docs/ontology/performsTask.md
+++ b/docs/ontology/performsTask.md
@@ -23,11 +23,11 @@ URI: [nexus:performsTask](https://ibm.github.io/risk-atlas-nexus/ontology/perfor
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
 
 
 

--- a/docs/ontology/producer.md
+++ b/docs/ontology/producer.md
@@ -23,11 +23,11 @@ URI: [nexus:producer](https://ibm.github.io/risk-atlas-nexus/ontology/producer)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
 | [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
 | [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
 
 
 

--- a/docs/ontology/refersToRisk.md
+++ b/docs/ontology/refersToRisk.md
@@ -1,0 +1,91 @@
+
+
+# Slot: refersToRisk
+
+
+_Indicates the incident (subject) is a materialisation of the indicated risk (object)_
+
+
+
+
+
+URI: [nexus:refersToRisk](https://ibm.github.io/risk-atlas-nexus/ontology/refersToRisk)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Risk](Risk.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:refersToRisk |
+| native | nexus:refersToRisk |
+| exact | dpv:refersToRisk |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: refersToRisk
+description: Indicates the incident (subject) is a materialisation of the indicated
+  risk (object)
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+exact_mappings:
+- dpv:refersToRisk
+rank: 1000
+domain: RiskIncident
+alias: refersToRisk
+domain_of:
+- RiskIncident
+range: Risk
+multivalued: true
+inlined: false
+
+```
+</details>

--- a/docs/ontology/riskincidents.md
+++ b/docs/ontology/riskincidents.md
@@ -1,0 +1,88 @@
+
+
+# Slot: riskincidents
+
+
+_A list of AI risk incidents_
+
+
+
+
+
+URI: [nexus:riskincidents](https://ibm.github.io/risk-atlas-nexus/ontology/riskincidents)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Container](Container.md) | An umbrella object that holds the ontology class instances |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [RiskIncident](RiskIncident.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | nexus:riskincidents |
+| native | nexus:riskincidents |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: riskincidents
+description: A list of AI risk incidents
+from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
+rank: 1000
+alias: riskincidents
+owner: Container
+domain_of:
+- Container
+range: RiskIncident
+multivalued: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/docs/ontology/source_uri.md
+++ b/docs/ontology/source_uri.md
@@ -1,15 +1,15 @@
 
 
-# Slot: value
+# Slot: source_uri
 
 
-_Some numeric or string value_
+_The uri of the incident_
 
 
 
 
 
-URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
+URI: [nexus:source_uri](https://ibm.github.io/risk-atlas-nexus/ontology/source_uri)
 
 
 
@@ -23,8 +23,7 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
-| [Fact](Fact.md) | A fact about something, for example the result of a measurement |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
 
 
 
@@ -35,8 +34,6 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 ## Properties
 
 * Range: [String](String.md)
-
-* Required: True
 
 
 
@@ -62,8 +59,8 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 | Mapping Type | Mapped Value |
 | ---  | ---  |
-| self | nexus:value |
-| native | nexus:value |
+| self | nexus:source_uri |
+| native | nexus:source_uri |
 
 
 
@@ -72,15 +69,15 @@ URI: [nexus:value](https://ibm.github.io/risk-atlas-nexus/ontology/value)
 
 <details>
 ```yaml
-name: value
-description: Some numeric or string value
+name: source_uri
+description: The uri of the incident
 from_schema: https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology
 rank: 1000
-alias: value
+alias: source_uri
+owner: RiskIncident
 domain_of:
-- Fact
+- RiskIncident
 range: string
-required: true
 
 ```
 </details>

--- a/docs/ontology/url.md
+++ b/docs/ontology/url.md
@@ -23,34 +23,45 @@ URI: [schema:url](http://schema.org/url)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
-| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
-| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
-| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
-| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
-| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
-| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
-| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
-| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
-| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
-| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
-| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
-| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
-| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
-| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
-| [AiModel](AiModel.md) | A base AI Model class |  no  |
-| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
-| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
-| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
-| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
-| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
-| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
-| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
-| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
-| [Action](Action.md) | Action to remediate a risk |  no  |
-| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
 | [AiEvalResult](AiEvalResult.md) | The result of an evaluation for a specific AI model |  no  |
+| [Entity](Entity.md) | A generic grouping for any identifiable entity |  no  |
+| [AiSystem](AiSystem.md) | A compound AI System composed of one or more AI capablities |  no  |
+| [AiLifecyclePhase](AiLifecyclePhase.md) | A Phase of AI lifecycle which indicates evolution of the system from concepti... |  no  |
+| [LargeLanguageModelFamily](LargeLanguageModelFamily.md) | A large language model family is a set of models that are provided by the sam... |  no  |
+| [IncidentMitigatedclass](IncidentMitigatedclass.md) |  |  no  |
+| [IncidentOngoingclass](IncidentOngoingclass.md) |  |  no  |
+| [Severity](Severity.md) |  |  no  |
+| [AiEval](AiEval.md) | An AI Evaluation, e |  no  |
+| [AiTask](AiTask.md) | A task, such as summarization and classification, performed by an AI |  no  |
+| [Organization](Organization.md) | Any organizational entity such as a corporation, educational institution, con... |  no  |
+| [Question](Question.md) | An evaluation where a question has to be answered |  no  |
+| [BaseAi](BaseAi.md) | Any type of AI, be it a LLM, RL agent, SVM, etc |  no  |
+| [AiProvider](AiProvider.md) | A provider under the AI Act is defined by Article 3(3) as a natural or legal ... |  no  |
+| [AiModel](AiModel.md) | A base AI Model class |  no  |
+| [IncidentHaltedclass](IncidentHaltedclass.md) |  |  no  |
+| [License](License.md) | The general notion of a license which defines terms and grants permissions to... |  no  |
+| [IncidentConcludedclass](IncidentConcludedclass.md) |  |  no  |
+| [AiModelValidation](AiModelValidation.md) | AI model validation steps that have been performed after the model training t... |  no  |
+| [RiskIncident](RiskIncident.md) | An event occuring or occured which is a realised or materialised risk |  no  |
+| [IncidentNearMissclass](IncidentNearMissclass.md) |  |  no  |
+| [Modality](Modality.md) | A modality supported by an Ai component |  no  |
 | [Risk](Risk.md) | The state of uncertainty associated with an AI system, that has the potential... |  no  |
+| [Consequence](Consequence.md) |  |  no  |
+| [Action](Action.md) | Action to remediate a risk |  no  |
+| [RiskControl](RiskControl.md) | A measure that maintains and/or modifies risk (and risk concepts) |  no  |
+| [Impact](Impact.md) |  |  no  |
+| [RiskTaxonomy](RiskTaxonomy.md) | A taxonomy of AI system related risks |  no  |
+| [Likelihood](Likelihood.md) |  |  no  |
+| [AiOffice](AiOffice.md) | The EU AI Office (https://digital-strategy |  no  |
+| [AiAgent](AiAgent.md) | An artificial intelligence (AI) agent refers to a system or program that is c... |  no  |
+| [Questionnaire](Questionnaire.md) | A questionnaire groups questions |  no  |
+| [Documentation](Documentation.md) | Documented information about a concept or other topic(s) of interest |  no  |
+| [LargeLanguageModel](LargeLanguageModel.md) | A large language model (LLM) is an AI model which supports a range of languag... |  no  |
+| [RiskGroup](RiskGroup.md) | A group of AI system related risks that are part of a risk taxonomy |  no  |
+| [Dataset](Dataset.md) | A body of structured information describing some topic(s) of interest |  no  |
+| [DataPreprocessing](DataPreprocessing.md) | Data transformations, such as PI filtering, performed to ensure high quality ... |  no  |
+| [IncidentStatus](IncidentStatus.md) |  |  no  |
+| [RiskConcept](RiskConcept.md) | An umbrella term for refering to risk, risk source, consequence and impact |  no  |
 
 
 

--- a/graph_export/owl/ai-risk-ontology_schema.ttl
+++ b/graph_export/owl/ai-risk-ontology_schema.ttl
@@ -15,10 +15,10 @@ nexus:AiAgent a owl:Class ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isProvidedBy ],
         nexus:AiSystem ;
     skos:definition "An artificial intelligence (AI) agent refers to a system or program that is capable of autonomously performing tasks on behalf of a user or another system by designing its workflow and utilizing available tools." ;
@@ -34,91 +34,127 @@ nexus:AiOffice a owl:Class ;
 nexus:Container a owl:Class ;
     rdfs:label "Container" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
-            owl:onProperty nexus:datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:documents ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:licenses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
-            owl:onProperty nexus:aimodelfamilies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
-            owl:onProperty nexus:modalities ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:evaluations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModel ;
-            owl:onProperty nexus:aimodels ],
+            owl:onProperty nexus:taxonomies ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:taxonomies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:modalities ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:documents ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:risks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:actions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
             owl:onProperty nexus:organizations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:aimodelfamilies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskIncident ;
+            owl:onProperty nexus:riskincidents ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
+            owl:onProperty nexus:aimodelfamilies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEval ;
+            owl:onProperty nexus:evaluations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:licenses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:aimodels ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Action ;
+            owl:onProperty nexus:actions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:riskincidents ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModel ;
+            owl:onProperty nexus:aimodels ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Risk ;
             owl:onProperty nexus:risks ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:modalities ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskgroups ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aimodelfamilies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aimodels ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
             owl:onProperty nexus:evaluations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:organizations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:actions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:licenses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aitasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Action ;
-            owl:onProperty nexus:actions ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskGroup ;
             owl:onProperty nexus:riskgroups ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
-            owl:onProperty nexus:aitasks ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:documents ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Modality ;
+            owl:onProperty nexus:modalities ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:taxonomies ],
+            owl:onProperty nexus:organizations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:risks ],
+            owl:onProperty nexus:riskgroups ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:documents ] ;
+            owl:onProperty nexus:licenses ] ;
     skos:definition "An umbrella object that holds the ontology class instances" ;
     skos:inScheme nexus:ai-risk-ontology .
+
+nexus:IncidentConcludedclass a owl:Class ;
+    rdfs:label "IncidentConcludedclass" ;
+    rdfs:subClassOf nexus:IncidentStatus ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentConcludedclass> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:IncidentHaltedclass a owl:Class ;
+    rdfs:label "IncidentHaltedclass" ;
+    rdfs:subClassOf nexus:IncidentStatus ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentHaltedclass> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:IncidentMitigatedclass a owl:Class ;
+    rdfs:label "IncidentMitigatedclass" ;
+    rdfs:subClassOf nexus:IncidentStatus ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentMitigatedclass> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:IncidentNearMissclass a owl:Class ;
+    rdfs:label "IncidentNearMissclass" ;
+    rdfs:subClassOf nexus:IncidentStatus ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentNearMissclass> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:IncidentOngoingclass a owl:Class ;
+    rdfs:label "IncidentOngoingclass" ;
+    rdfs:subClassOf nexus:IncidentStatus ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentOngoingclass> ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:Questionnaire a owl:Class ;
     rdfs:label "Questionnaire" ;
@@ -126,10 +162,10 @@ nexus:Questionnaire a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:composed_of ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:Question ;
             owl:onProperty nexus:composed_of ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Question ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:composed_of ],
         nexus:AiEval ;
     skos:definition "A questionnaire groups questions" ;
@@ -174,14 +210,32 @@ nexus:validated_by a owl:ObjectProperty ;
 nexus:AiModel a owl:Class ;
     rdfs:label "AiModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:gpu_hours ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:gpu_hours ],
+            owl:onProperty nexus:power_consumption_w ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:power_consumption_w ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:power_consumption_w ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEvalResult ;
+            owl:onProperty nexus:hasEvaluation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:architecture ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -189,11 +243,11 @@ nexus:AiModel a owl:Class ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:gpu_hours ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEvalResult ;
-            owl:onProperty nexus:hasEvaluation ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRiskControl ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:power_consumption_w ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:gpu_hours ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:float [ a rdfs:Datatype ;
@@ -201,35 +255,17 @@ nexus:AiModel a owl:Class ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:architecture ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:power_consumption_w ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:architecture ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRiskControl ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:hasRiskControl ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasEvaluation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:carbon_emitted ],
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:hasRiskControl ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:power_consumption_w ],
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:gpu_hours ],
         nexus:BaseAi ;
     skos:definition "A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclassed by model types (see LargeLanguageModel)." ;
     skos:inScheme nexus:ai_system .
@@ -243,29 +279,29 @@ nexus:AiModelValidation a owl:Class ;
 nexus:AiSystem a owl:Class ;
     rdfs:label "AiSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiSystemType ;
+            owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasEuAiSystemType ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:EuAiRiskCategory ;
-            owl:onProperty nexus:hasEuRiskCategory ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiSystemType ;
-            owl:onProperty nexus:hasEuAiSystemType ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:isComposedOf ],
+            owl:onProperty nexus:hasEuRiskCategory ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:EuAiRiskCategory ;
+            owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasEuAiSystemType ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:BaseAi ;
             owl:onProperty nexus:isComposedOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEuRiskCategory ],
         nexus:BaseAi ;
     skos:definition "A compound AI System composed of one or more AI capablities. ChatGPT is an example of an AI system which deploys multiple GPT AI models." ;
     skos:exactMatch airo:AISystem ;
@@ -280,19 +316,19 @@ nexus:DataPreprocessing a owl:Class ;
 nexus:Fact a owl:Class ;
     rdfs:label "Fact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:evidence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:evidence ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty nexus:value ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:evidence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:value ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty nexus:evidence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:value ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -305,25 +341,40 @@ nexus:LargeLanguageModel a owl:Class ;
     rdfs:label "LargeLanguageModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:fine_tuning ],
+            owl:onProperty nexus:numTrainingTokens ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
-            owl:onProperty nexus:hasInputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:supported_languages ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:numParameters ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:contextWindowSize ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:numTrainingTokens ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:supported_languages ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:numTrainingTokens ],
@@ -331,56 +382,41 @@ nexus:LargeLanguageModel a owl:Class ;
             owl:allValuesFrom nexus:Dataset ;
             owl:onProperty nexus:hasTrainingData ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:fine_tuning ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:supported_languages ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:numParameters ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:numParameters ],
+            owl:onProperty nexus:contextWindowSize ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:contextWindowSize ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasTrainingData ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasOutputModality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Modality ;
+            owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:supported_languages ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
             owl:allValuesFrom nexus:Modality ;
             owl:onProperty nexus:hasOutputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasOutputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:numTrainingTokens ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:numTrainingTokens ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:fine_tuning ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:contextWindowSize ],
         nexus:AiModel ;
     skos:altLabel "LLM" ;
     skos:definition "A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture." ;
@@ -407,10 +443,10 @@ nexus:AiEvalResult a owl:Class ;
             owl:allValuesFrom nexus:AiEval ;
             owl:onProperty nexus:isResultOf ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isResultOf ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:isResultOf ],
         nexus:Entity,
         nexus:Fact ;
@@ -456,6 +492,12 @@ nexus:AiProvider a owl:Class ;
     rdfs:label "SCIENTIFIC_RD" ;
     rdfs:subClassOf nexus:AiSystemType .
 
+nexus:Consequence a owl:Class ;
+    rdfs:label "Consequence" ;
+    rdfs:subClassOf nexus:Entity ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#Consequence> ;
+    skos:inScheme nexus:ai_risk .
+
 <https://ibm.github.io/risk-atlas-nexus/ontology/EuAiRiskCategory#HIGH> a owl:Class ;
     rdfs:label "HIGH" ;
     rdfs:subClassOf nexus:EuAiRiskCategory .
@@ -483,6 +525,18 @@ nexus:LargeLanguageModelFamily a owl:Class ;
         nexus:Entity ;
     skos:definition "A large language model family is a set of models that are provided by the same AI systems provider and are built around the same architecture, but differ e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite models." ;
     skos:inScheme nexus:ai_system .
+
+nexus:Likelihood a owl:Class ;
+    rdfs:label "Likelihood" ;
+    rdfs:subClassOf nexus:Entity ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#Likelihood> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:Severity a owl:Class ;
+    rdfs:label "Severity" ;
+    rdfs:subClassOf nexus:Entity ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#Severity> ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:actions a owl:ObjectProperty ;
     rdfs:label "actions" ;
@@ -598,6 +652,14 @@ nexus:performsTask a owl:ObjectProperty ;
     skos:definition "relationship indicating the AI tasks an AI model can perform." ;
     skos:inScheme nexus:ai_system .
 
+nexus:refersToRisk a owl:ObjectProperty ;
+    rdfs:label "refersToRisk" ;
+    rdfs:domain nexus:RiskIncident ;
+    rdfs:range nexus:Risk ;
+    skos:definition "Indicates the incident (subject) is a materialisation of the indicated risk (object)" ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#refersToRisk> ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:riskcontrols a owl:ObjectProperty ;
     rdfs:label "riskcontrols" ;
     skos:definition "A list of AI risk controls" ;
@@ -606,6 +668,11 @@ nexus:riskcontrols a owl:ObjectProperty ;
 nexus:riskgroups a owl:ObjectProperty ;
     rdfs:label "riskgroups" ;
     skos:definition "A list of AI risk groups" ;
+    skos:inScheme nexus:ai-risk-ontology .
+
+nexus:riskincidents a owl:ObjectProperty ;
+    rdfs:label "riskincidents" ;
+    skos:definition "A list of AI risk incidents" ;
     skos:inScheme nexus:ai-risk-ontology .
 
 nexus:risks a owl:ObjectProperty ;
@@ -627,32 +694,32 @@ nexus:taxonomies a owl:ObjectProperty ;
 nexus:Action a owl:Class ;
     rdfs:label "Action" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasAiActorTask ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasAiActorTask ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasAiActorTask ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Risk ;
             owl:onProperty nexus:hasRelatedRisk ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedRisk ],
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
         nexus:Entity ;
     skos:definition "Action to remediate a risk" ;
     skos:inScheme nexus:ai_risk .
@@ -667,17 +734,11 @@ nexus:AiTask a owl:Class ;
 nexus:BaseAi a owl:Class ;
     rdfs:label "BaseAi" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:producer ],
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:producer ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiProvider ;
-            owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
@@ -685,32 +746,38 @@ nexus:BaseAi a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:performsTask ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:producer ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:performsTask ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:producer ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isProvidedBy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
+            owl:onProperty nexus:producer ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasModelCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiProvider ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasModelCard ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isProvidedBy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
-            owl:onProperty nexus:performsTask ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasModelCard ],
         nexus:Entity ;
     skos:definition "Any type of AI, be it a LLM, RL agent, SVM, etc." ;
     skos:inScheme nexus:ai_system .
@@ -720,6 +787,11 @@ nexus:architecture a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     skos:definition "A description of the architecture of an AI such as 'Decoder-only'." ;
     skos:inScheme nexus:ai_system .
+
+nexus:author a owl:DatatypeProperty ;
+    rdfs:label "author" ;
+    skos:definition "The author or authors of the incident report" ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:bestValue a owl:DatatypeProperty ;
     rdfs:label "bestValue" ;
@@ -797,6 +869,13 @@ nexus:grants_license a owl:ObjectProperty ;
     skos:definition "A relationship from a granting entity such as an Organization to a License instance." ;
     skos:inScheme nexus:common .
 
+nexus:hasConsequence a owl:ObjectProperty ;
+    rdfs:label "hasConsequence" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:Consequence ;
+    skos:definition "Indicates consequence(s) possible or arising from specified concept" ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:hasEuAiSystemType a owl:ObjectProperty ;
     rdfs:label "hasEuAiSystemType" ;
     rdfs:range nexus:AiSystemType ;
@@ -809,11 +888,55 @@ nexus:hasEuRiskCategory a owl:ObjectProperty ;
     skos:definition "The risk category of an AI system as defined by the EU AI Act." ;
     skos:inScheme nexus:eu_ai_act .
 
+nexus:hasImpact a owl:ObjectProperty ;
+    rdfs:label "hasImpact" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:Impact ;
+    skos:broadMatch <https://w3c.github.io/dpv/2.1/dpv/#hasConsequence> ;
+    skos:definition "Indicates impact(s) possible or arising as consequences from specified concept" ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:hasImpactOn a owl:ObjectProperty ;
+    rdfs:label "hasImpactOn" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:Impact ;
+    skos:broadMatch <https://w3c.github.io/dpv/2.1/dpv/#hasConsequenceOn> ;
+    skos:definition "Indicates impact(s) possible or arising as consequences from specified concept" ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:hasLikelihood a owl:ObjectProperty ;
+    rdfs:label "hasLikelihood" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:Likelihood ;
+    skos:definition "The likelihood or probability or chance of something taking place or occuring" ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:hasSeverity a owl:ObjectProperty ;
+    rdfs:label "hasSeverity" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:Severity ;
+    skos:definition "Indicates the severity associated with a concept" ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:hasStatus a owl:ObjectProperty ;
+    rdfs:label "hasStatus" ;
+    rdfs:domain nexus:RiskConcept ;
+    rdfs:range nexus:IncidentStatus ;
+    skos:definition "Indicates the status of specified concept" ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:hasUnitxtCard a owl:DatatypeProperty ;
     rdfs:label "hasUnitxtCard" ;
     rdfs:range xsd:anyURI ;
     skos:definition "A relationship to a Unitxt card defining the risk evaluation" ;
     skos:inScheme nexus:ai_eval .
+
+nexus:hasVariant a owl:ObjectProperty ;
+    rdfs:label "hasVariant" ;
+    rdfs:domain nexus:RiskIncident ;
+    rdfs:range nexus:RiskIncident ;
+    skos:definition "Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident. " ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:id a owl:DatatypeProperty ;
     rdfs:label "id" ;
@@ -883,6 +1006,11 @@ nexus:provider a owl:ObjectProperty ;
     skos:definition "A relationship to the Organization instance that provides this instance." ;
     skos:inScheme nexus:common .
 
+nexus:source_uri a owl:DatatypeProperty ;
+    rdfs:label "source_uri" ;
+    skos:definition "The uri of the incident" ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:tag a owl:DatatypeProperty ;
     rdfs:label "tag" ;
     skos:definition "A shost version of the name" ;
@@ -908,6 +1036,13 @@ nexus:value a owl:DatatypeProperty ;
     rdfs:label "value" ;
     skos:definition "Some numeric or string value" ;
     skos:inScheme nexus:common .
+
+nexus:Impact a owl:Class ;
+    rdfs:label "Impact" ;
+    rdfs:subClassOf nexus:Entity,
+        nexus:RiskConcept ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#Impact> ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:broadMatch a owl:ObjectProperty ;
     rdfs:label "broadMatch" ;
@@ -955,25 +1090,25 @@ nexus:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:provider ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:provider ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
+            owl:onProperty nexus:provider ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
+            owl:onProperty nexus:provider ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:provider ],
@@ -989,6 +1124,110 @@ nexus:Modality a owl:Class ;
     skos:exactMatch airo:Modality ;
     skos:inScheme nexus:ai_system .
 
+nexus:RiskIncident a owl:Class ;
+    rdfs:label "RiskIncident" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Consequence ;
+            owl:onProperty nexus:hasConsequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:source_uri ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasSeverity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:author ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasConsequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskIncident ;
+            owl:onProperty nexus:hasVariant ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLikelihood ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLikelihood ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:author ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasVariant ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasVariant ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:IncidentStatus ;
+            owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasConsequence ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasImpact ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:source_uri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:author ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasSeverity ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Severity ;
+            owl:onProperty nexus:hasSeverity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Impact ;
+            owl:onProperty nexus:hasImpact ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Impact ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:source_uri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:refersToRisk ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Likelihood ;
+            owl:onProperty nexus:hasLikelihood ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasImpact ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:refersToRisk ],
+        nexus:Entity,
+        nexus:RiskConcept ;
+    skos:definition "An event occuring or occured which is a realised or materialised risk." ;
+    skos:exactMatch <https://w3id.org/dpv/risk#Incident> ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:detectsRiskConcept a owl:ObjectProperty ;
     rdfs:label "detectsRiskConcept" ;
     rdfs:domain nexus:RiskControl ;
@@ -1001,56 +1240,56 @@ nexus:detectsRiskConcept a owl:ObjectProperty ;
 nexus:AiEval a owl:Class ;
     rdfs:label "AiEval" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasUnitxtCard ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasRelatedRisk ],
         [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:hasDataset ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
+            owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
             owl:onProperty nexus:hasUnitxtCard ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasUnitxtCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataset ],
+            owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasUnitxtCard ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:bestValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isComposedOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedRisk ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
-            owl:onProperty nexus:isComposedOf ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:bestValue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
-            owl:onProperty nexus:hasDataset ],
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEval ;
+            owl:onProperty nexus:isComposedOf ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:hasRelatedRisk ],
         nexus:Entity ;
     skos:definition "An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a question or a combination of such entities." ;
     skos:exactMatch <https://www.w3.org/TR/vocab-dqv/Metric> ;
@@ -1066,14 +1305,14 @@ nexus:EuAiRiskCategory a owl:Class ;
 nexus:RiskControl a owl:Class ;
     rdfs:label "RiskControl" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskConcept ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskConcept ;
-            owl:onProperty nexus:detectsRiskConcept ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:detectsRiskConcept ],
@@ -1084,36 +1323,6 @@ nexus:RiskControl a owl:Class ;
         nexus:RiskConcept ;
     skos:definition "A measure that maintains and/or modifies risk (and risk concepts)" ;
     skos:exactMatch airo:RiskControl ;
-    skos:inScheme nexus:ai_risk .
-
-nexus:RiskTaxonomy a owl:Class ;
-    rdfs:label "RiskTaxonomy" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
-        nexus:Entity ;
-    skos:definition "A taxonomy of AI system related risks" ;
     skos:inScheme nexus:ai_risk .
 
 nexus:isPartOf a owl:DatatypeProperty ;
@@ -1131,6 +1340,42 @@ nexus:version a owl:DatatypeProperty ;
     rdfs:label "version" ;
     skos:definition "The version of the entity embodied by a specified resource." ;
     skos:inScheme nexus:common .
+
+nexus:IncidentStatus a owl:Class ;
+    rdfs:label "IncidentStatus" ;
+    rdfs:subClassOf nexus:Entity ;
+    skos:exactMatch <https://w3c.github.io/dpv/2.1/dpv/#IncidentStatus> ;
+    skos:inScheme nexus:ai_risk .
+
+nexus:RiskTaxonomy a owl:Class ;
+    rdfs:label "RiskTaxonomy" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        nexus:Entity ;
+    skos:definition "A taxonomy of AI system related risks" ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:AiSystemType a owl:Class ;
     owl:unionOf ( <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#GPAI_OS> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#PROHIBITED> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#SCIENTIFIC_RD> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#MILITARY_SECURITY> <https://ibm.github.io/risk-atlas-nexus/ontology/AiSystemType#HIGH_RISK> ) ;
@@ -1151,42 +1396,29 @@ nexus:Documentation a owl:Class ;
 nexus:License a owl:Class ;
     rdfs:label "License" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:version ],
         nexus:Entity ;
     skos:definition "The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software." ;
     skos:exactMatch airo:License ;
     skos:inScheme nexus:common .
 
-nexus:RiskConcept a owl:Class ;
-    rdfs:label "RiskConcept" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:isDetectedBy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDetectedBy ],
-        nexus:Entity ;
-    skos:definition "An umbrella term for refering to risk, risk source, consequence and impact." ;
-    skos:exactMatch airo:RiskConcept ;
-    skos:inScheme nexus:ai_risk .
-
 nexus:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:grants_license ],
+        [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:grants_license ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:grants_license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:grants_license ],
         nexus:Entity ;
     skos:definition "Any organizational entity such as a corporation, educational institution, consortium, government, etc." ;
@@ -1205,123 +1437,76 @@ nexus:hasLicense a owl:ObjectProperty ;
     skos:definition "Indicates licenses associated with a resource" ;
     skos:inScheme nexus:common .
 
+nexus:Any a owl:Class ;
+    rdfs:label "Any" ;
+    skos:exactMatch linkml:Any ;
+    skos:inScheme nexus:ai_risk .
+
 nexus:isDefinedByTaxonomy a owl:ObjectProperty ;
     rdfs:label "isDefinedByTaxonomy" ;
     rdfs:range nexus:RiskTaxonomy ;
     skos:definition "A relationship where a risk or a risk group is defined by a risk taxonomy" ;
     skos:inScheme nexus:ai_risk .
 
-nexus:Any a owl:Class ;
-    rdfs:label "Any" ;
-    skos:exactMatch linkml:Any ;
-    skos:inScheme nexus:ai_risk .
-
-nexus:Entity a owl:Class ;
-    rdfs:label "Entity" ;
+nexus:RiskConcept a owl:Class ;
+    rdfs:label "RiskConcept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateModified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:description ],
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:isDetectedBy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty nexus:url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty nexus:dateModified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:dateModified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:url ] ;
-    skos:definition "A generic grouping for any identifiable entity." ;
-    skos:exactMatch <http://schema.org/Thing> ;
-    skos:inScheme nexus:common .
+            owl:onProperty nexus:isDetectedBy ],
+        nexus:Entity ;
+    skos:definition "An umbrella term for refering to risk, risk source, consequence and impact." ;
+    skos:exactMatch airo:RiskConcept ;
+    skos:inScheme nexus:ai_risk .
 
 nexus:RiskGroup a owl:Class ;
     rdfs:label "RiskGroup" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:narrowMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Risk ;
             owl:onProperty nexus:hasPart ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasPart ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         nexus:Entity,
         nexus:RiskConcept ;
@@ -1331,114 +1516,174 @@ nexus:RiskGroup a owl:Class ;
 nexus:Risk a owl:Class ;
     rdfs:label "Risk" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:exactMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskGroup ;
             owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedAction ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskConcept ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:phase ],
+            owl:onProperty nexus:tag ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedAction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:descriptor ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:tag ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:tag ],
+            owl:onProperty nexus:detectsRiskConcept ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:tag ],
+            owl:onProperty nexus:descriptor ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskConcept ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:relatedMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Action ;
             owl:onProperty nexus:hasRelatedAction ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:phase ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:concern ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:phase ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:broadMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:exactMatch ],
+            owl:onProperty nexus:descriptor ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:tag ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "The state of uncertainty associated with an AI system, that has the potential to cause harms" ;
     skos:exactMatch airo:Risk ;
     skos:inScheme nexus:ai_risk .
+
+nexus:Entity a owl:Class ;
+    rdfs:label "Entity" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateCreated ] ;
+    skos:definition "A generic grouping for any identifiable entity." ;
+    skos:exactMatch <http://schema.org/Thing> ;
+    skos:inScheme nexus:common .
 
 

--- a/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -492,9 +492,10 @@ class RiskIncident(RiskConcept, Entity):
          'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
          'mixins': ['RiskConcept']})
 
-    refersToRisk: Optional[str] = Field(default=None, description="""Indicates the incident (subject) is a materialisation of the indicated risk (object)""", json_schema_extra = { "linkml_meta": {'alias': 'refersToRisk',
+    refersToRisk: Optional[List[str]] = Field(default=None, description="""Indicates the incident (subject) is a materialisation of the indicated risk (object)""", json_schema_extra = { "linkml_meta": {'alias': 'refersToRisk',
          'domain': 'RiskIncident',
-         'domain_of': ['RiskIncident']} })
+         'domain_of': ['RiskIncident'],
+         'exact_mappings': ['dpv:refersToRisk']} })
     isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
          'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
          'slot_uri': 'schema:isPartOf'} })

--- a/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -307,7 +307,7 @@ class RiskGroup(RiskConcept, Entity):
                                     'range': 'Risk'}}})
 
     isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
+         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
          'slot_uri': 'schema:isPartOf'} })
     closeMatch: Optional[List[str]] = Field(default=None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
          'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
@@ -362,7 +362,7 @@ class Risk(RiskConcept, Entity):
 
     hasRelatedAction: Optional[List[str]] = Field(default=None, description="""A relationship where an entity relates to an action""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedAction', 'domain_of': ['Risk']} })
     isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
+         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
          'slot_uri': 'schema:isPartOf'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where a risk is part of a risk group""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
          'domain_of': ['Risk', 'LargeLanguageModel'],
@@ -429,7 +429,7 @@ class RiskControl(RiskConcept, Entity):
          'exact_mappings': ['airo:detectsRiskConcept'],
          'inverse': 'isDetectedBy'} })
     isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
+         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
          'slot_uri': 'schema:isPartOf'} })
     isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
          'domain': 'RiskConcept',
@@ -467,9 +467,245 @@ class Action(Entity):
                        'LargeLanguageModelFamily'],
          'slot_uri': 'airo:hasDocumentation'} })
     isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action'],
+         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
          'slot_uri': 'schema:isPartOf'} })
     hasAiActorTask: Optional[List[str]] = Field(default=None, description="""Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed will apply to every suggested action in the subcategory (i.e., some apply to AI development and others apply to AI deployment).""", json_schema_extra = { "linkml_meta": {'alias': 'hasAiActorTask', 'domain_of': ['Action']} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class RiskIncident(RiskConcept, Entity):
+    """
+    An event occuring or occured which is a realised or materialised risk.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'https://w3id.org/dpv/risk#Incident',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
+         'mixins': ['RiskConcept']})
+
+    refersToRisk: Optional[str] = Field(default=None, description="""Indicates the incident (subject) is a materialisation of the indicated risk (object)""", json_schema_extra = { "linkml_meta": {'alias': 'refersToRisk',
+         'domain': 'RiskIncident',
+         'domain_of': ['RiskIncident']} })
+    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
+         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
+         'slot_uri': 'schema:isPartOf'} })
+    hasStatus: Optional[str] = Field(default=None, description="""Indicates the status of specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasStatus', 'domain': 'RiskConcept', 'domain_of': ['RiskIncident']} })
+    hasSeverity: Optional[str] = Field(default=None, description="""Indicates the severity associated with a concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasSeverity', 'domain': 'RiskConcept', 'domain_of': ['RiskIncident']} })
+    hasLikelihood: Optional[str] = Field(default=None, description="""The likelihood or probability or chance of something taking place or occuring""", json_schema_extra = { "linkml_meta": {'alias': 'hasLikelihood',
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskIncident']} })
+    hasImpactOn: Optional[str] = Field(default=None, description="""Indicates impact(s) possible or arising as consequences from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasImpactOn',
+         'broad_mappings': ['dpv:hasConsequenceOn'],
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskIncident']} })
+    hasConsequence: Optional[str] = Field(default=None, description="""Indicates consequence(s) possible or arising from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasConsequence',
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskIncident']} })
+    hasImpact: Optional[str] = Field(default=None, description="""Indicates impact(s) possible or arising as consequences from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasImpact',
+         'broad_mappings': ['dpv:hasConsequence'],
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskIncident']} })
+    hasVariant: Optional[str] = Field(default=None, description="""Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident. """, json_schema_extra = { "linkml_meta": {'alias': 'hasVariant', 'domain': 'RiskIncident', 'domain_of': ['RiskIncident']} })
+    author: Optional[str] = Field(default=None, description="""The author or authors of the incident report""", json_schema_extra = { "linkml_meta": {'alias': 'author', 'domain_of': ['RiskIncident']} })
+    source_uri: Optional[str] = Field(default=None, description="""The uri of the incident""", json_schema_extra = { "linkml_meta": {'alias': 'source_uri', 'domain_of': ['RiskIncident']} })
+    isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskConcept'],
+         'inverse': 'detectsRiskConcept'} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class Impact(RiskConcept, Entity):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Impact',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
+         'mixins': ['RiskConcept']})
+
+    isDetectedBy: Optional[List[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
+         'domain': 'RiskConcept',
+         'domain_of': ['RiskConcept'],
+         'inverse': 'detectsRiskConcept'} })
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentStatus(Entity):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentStatus',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentConcludedclass(IncidentStatus):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentConcludedclass',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentHaltedclass(IncidentStatus):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentHaltedclass',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentMitigatedclass(IncidentStatus):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentMitigatedclass',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentNearMissclass(IncidentStatus):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentNearMissclass',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class IncidentOngoingclass(IncidentStatus):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentOngoingclass',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class Severity(Entity):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Severity',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class Likelihood(Entity):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Likelihood',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
+    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
+    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
+    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:description'} })
+    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
+    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateCreated'} })
+    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
+         'domain_of': ['Entity'],
+         'slot_uri': 'schema:dateModified'} })
+
+
+class Consequence(Entity):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Consequence',
+         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+
     id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
     name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity'], 'slot_uri': 'schema:name'} })
     description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
@@ -1070,6 +1306,7 @@ class Container(ConfiguredBaseModel):
     riskgroups: Optional[List[RiskGroup]] = Field(default=None, description="""A list of AI risk groups""", json_schema_extra = { "linkml_meta": {'alias': 'riskgroups', 'domain_of': ['Container']} })
     risks: Optional[List[Risk]] = Field(default=None, description="""A list of AI risks""", json_schema_extra = { "linkml_meta": {'alias': 'risks', 'domain_of': ['Container']} })
     riskcontrols: Optional[List[RiskControl]] = Field(default=None, description="""A list of AI risk controls""", json_schema_extra = { "linkml_meta": {'alias': 'riskcontrols', 'domain_of': ['Container']} })
+    riskincidents: Optional[List[RiskIncident]] = Field(default=None, description="""A list of AI risk incidents""", json_schema_extra = { "linkml_meta": {'alias': 'riskincidents', 'domain_of': ['Container']} })
     actions: Optional[List[Action]] = Field(default=None, description="""A list of risk related actions""", json_schema_extra = { "linkml_meta": {'alias': 'actions', 'domain_of': ['Container']} })
     evaluations: Optional[List[AiEval]] = Field(default=None, description="""A list of AI evaluation methods""", json_schema_extra = { "linkml_meta": {'alias': 'evaluations', 'domain_of': ['Container']} })
     aimodelfamilies: Optional[List[LargeLanguageModelFamily]] = Field(default=None, description="""A list of AI model families""", json_schema_extra = { "linkml_meta": {'alias': 'aimodelfamilies', 'domain_of': ['Container']} })
@@ -1090,6 +1327,17 @@ RiskGroup.model_rebuild()
 Risk.model_rebuild()
 RiskControl.model_rebuild()
 Action.model_rebuild()
+RiskIncident.model_rebuild()
+Impact.model_rebuild()
+IncidentStatus.model_rebuild()
+IncidentConcludedclass.model_rebuild()
+IncidentHaltedclass.model_rebuild()
+IncidentMitigatedclass.model_rebuild()
+IncidentNearMissclass.model_rebuild()
+IncidentOngoingclass.model_rebuild()
+Severity.model_rebuild()
+Likelihood.model_rebuild()
+Consequence.model_rebuild()
 AiEval.model_rebuild()
 AiEvalResult.model_rebuild()
 Question.model_rebuild()

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml
@@ -88,6 +88,12 @@ classes:
         range: RiskControl
         inlined: true
         inlined_as_list: true
+      riskincidents:
+        description: A list of AI risk incidents
+        multivalued: true
+        range: RiskIncident
+        inlined: true
+        inlined_as_list: true
       actions:
         description: A list of risk related actions
         multivalued: true

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_risk.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/ai_risk.yaml
@@ -11,6 +11,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
   nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
+  dpv: https://w3c.github.io/dpv/2.1/dpv/#
 default_range: string
 default_prefix: nexus
 
@@ -103,7 +104,71 @@ classes:
 
   Any:
     class_uri: linkml:Any
-    
+
+  RiskIncident:
+    is_a: Entity
+    mixins:
+      - RiskConcept
+    class_uri: https://w3id.org/dpv/risk#Incident
+    description: An event occuring or occured which is a realised or materialised risk.
+    attributes:
+      author: 
+        description: The author or authors of the incident report
+      source_uri: 
+        description: The uri of the incident
+    slots:
+      - refersToRisk
+      - isDefinedByTaxonomy
+      - hasStatus
+      - hasSeverity
+      - hasLikelihood
+      - hasImpactOn
+      - hasConsequence
+      - hasImpact
+      - hasVariant
+
+  Impact:
+    is_a: Entity
+    mixins: 
+      - RiskConcept
+    class_uri: dpv:Impact
+
+  IncidentStatus:
+    is_a: Entity
+    class_uri: dpv:IncidentStatus
+
+  IncidentConcludedclass:
+    is_a: IncidentStatus
+    class_uri: dpv:IncidentConcludedclass
+
+  IncidentHaltedclass:
+    is_a: IncidentStatus
+    class_uri: dpv:IncidentHaltedclass
+
+  IncidentMitigatedclass:
+    is_a: IncidentStatus
+    class_uri: dpv:IncidentMitigatedclass
+
+  IncidentNearMissclass:
+    is_a: IncidentStatus
+    class_uri: dpv:IncidentNearMissclass
+
+  IncidentOngoingclass:
+    is_a: IncidentStatus
+    class_uri: dpv:IncidentOngoingclass
+
+  Severity:
+    is_a: Entity
+    class_uri: dpv:Severity
+  
+  Likelihood:
+    is_a: Entity
+    class_uri: dpv:Likelihood
+
+  Consequence:
+    is_a: Entity
+    class_uri: dpv:Consequence
+
 slots:
   isDefinedByTaxonomy:
     slot_uri: schema:isPartOf
@@ -187,3 +252,53 @@ slots:
     multivalued: true
     inlined: false
     inverse: detectsRiskConcept
+  hasStatus:
+    description: >-
+      Indicates the status of specified concept
+    domain: RiskConcept
+    range: IncidentStatus
+  hasSeverity:
+    description: >-
+      Indicates the severity associated with a concept
+    domain: RiskConcept
+    range: Severity
+  hasLikelihood:
+    description: >-
+      The likelihood or probability or chance of something taking place or occuring
+    domain: RiskConcept
+    range: Likelihood
+  hasImpactOn:
+    description: >-
+      Indicates impact(s) possible or arising as consequences from specified concept
+    domain: RiskConcept
+    range: Impact
+    broad_mappings: 
+    - dpv:hasConsequenceOn
+  hasConsequence:
+    description: >-
+      Indicates consequence(s) possible or arising from specified concept
+    domain: RiskConcept
+    range: Consequence
+  hasImpact:
+    description: >-
+      Indicates impact(s) possible or arising as consequences from specified concept
+    domain: RiskConcept
+    range: Impact
+    broad_mappings: 
+    - dpv:hasConsequence
+  hasVariant:
+    description: >-
+      Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident. 
+    domain: RiskIncident
+    range: RiskIncident
+  refersToRisk:
+    exact_mappings:
+    - dpv:refersToRisk
+    description: >-
+      Indicates the incident (subject) is a materialisation of the indicated risk (object)
+    domain: RiskIncident
+    range: Risk
+    multivalued: true
+    inlined: false
+
+

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/common.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/common.yaml
@@ -10,6 +10,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
   airo: https://w3id.org/airo#
   nexus: https://ibm.github.io/risk-atlas-nexus/ontology/
+  dpv: https://w3c.github.io/dpv/2.1/dpv/#
 
 default_range: string
 default_prefix: nexus

--- a/src/risk_atlas_nexus/ai_risk_ontology/schema/semweb_context.yaml
+++ b/src/risk_atlas_nexus/ai_risk_ontology/schema/semweb_context.yaml
@@ -18,4 +18,5 @@
   prov: http://www.w3.org/ns/prov#
   dcat: http://www.w3.org/ns/dcat#
   dqv: https://www.w3.org/TR/vocab-dqv/#dqv
+  dpv: https://w3c.github.io/dpv/2.1/dpv/#
   

--- a/src/risk_atlas_nexus/blocks/risk_detector/base.py
+++ b/src/risk_atlas_nexus/blocks/risk_detector/base.py
@@ -1,7 +1,7 @@
 import json
 import os
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional
 from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
 from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import (
     Container,
@@ -67,5 +67,5 @@ class RiskDetector(ABC):
             )
 
     @abstractmethod
-    def detect(self, usecases: List[str]) -> List[Risk]:
+    def detect(self, usecases: list[str]) -> list[Risk]:
         raise NotImplementedError

--- a/src/risk_atlas_nexus/blocks/risk_detector/generic.py
+++ b/src/risk_atlas_nexus/blocks/risk_detector/generic.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 
 from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
 from risk_atlas_nexus.blocks.inference import TextGenerationInferenceOutput
@@ -10,7 +9,7 @@ from risk_atlas_nexus.blocks.inference.response_schema import LIST_OF_STR_SCHEMA
 
 class GenericRiskDetector(RiskDetector):
 
-    def detect(self, usecases: List[str]) -> List[Risk]:
+    def detect(self, usecases: list[str]) -> list[Risk]:
         prompts = [
             self.inference_engine.prepare_prompt(
                 prompt_template=RISK_IDENTIFICATION_TEMPLATE,

--- a/src/risk_atlas_nexus/blocks/risk_mapping/base.py
+++ b/src/risk_atlas_nexus/blocks/risk_mapping/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List
 from sssom_schema import Mapping
 from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
 
@@ -14,8 +13,8 @@ class RiskMappingBase(ABC):
 
     def __init__(
         self,
-        new_risks: List[Risk],
-        existing_risks: List[Risk],
+        new_risks: list[Risk],
+        existing_risks: list[Risk],
         inference_engine: InferenceEngine,
         new_prefix: str,  
         mapping_method: MappingMethod
@@ -27,6 +26,6 @@ class RiskMappingBase(ABC):
         self._mapping_method = mapping_method
 
     @abstractmethod
-    def generate(self, new_risks: List[Risk], existing_risks: List[Risk],  inference_engine: InferenceEngine,
-                 new_prefix: str,  mapping_method: MappingMethod) -> List[Mapping]:
+    def generate(self, new_risks: list[Risk], existing_risks: list[Risk],  inference_engine: InferenceEngine,
+                 new_prefix: str,  mapping_method: MappingMethod) -> list[Mapping]:
         raise NotImplementedError

--- a/src/risk_atlas_nexus/blocks/risk_mapping/risk_mapper.py
+++ b/src/risk_atlas_nexus/blocks/risk_mapping/risk_mapper.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-from typing import List
+
 from txtai import Embeddings
 from sssom_schema import Mapping, EntityReference
 from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
@@ -51,13 +51,13 @@ class RiskMapper(RiskMappingBase):
         s = curie_prefix.strip() + ":" + entity_id.strip()
         return EntityReference(s)
 
-    def generate(self, new_risks: List[Risk], existing_risks: List[Risk], inference_engine:InferenceEngine,
-                 new_prefix: str, mapping_method: MappingMethod) -> List[Mapping]:
+    def generate(self, new_risks: list[Risk], existing_risks: list[Risk], inference_engine:InferenceEngine,
+                 new_prefix: str, mapping_method: MappingMethod) -> list[Mapping]:
         """Generate a list of mappings between two lists of risks
         Args:
-            new_risks: List[Risk]
+            new_risks: list[Risk]
                 A new set of risks
-            existing_risks: List[Risk],
+            existing_risks: list[Risk],
                 Secondary list, this should be the list of existing risks in RAN
             inference_engine: (Optional)Union[InferenceEngine | None]:
                 An LLM inference engine to infer risks from the usecases.
@@ -67,7 +67,7 @@ class RiskMapper(RiskMappingBase):
                 The method to generate the mapping
 
         Returns:
-            List[Mapping]
+            list[Mapping]
         """
         mappings = []
        

--- a/src/risk_atlas_nexus/data/mappings/README.md
+++ b/src/risk_atlas_nexus/data/mappings/README.md
@@ -1,0 +1,7 @@
+# Mappings
+
+- Mappings should be stored in .tsv files this folder.
+- The mappings are lifted from the the tsv files to the yaml format and stored in the yaml data mappings folder, with the help of a script in the makefile.
+
+
+**Disclaimer**: some of the mappings in this folder have been generated or refined with the help of LLM : "ibm/granite-20b-code-instruct"

--- a/src/risk_atlas_nexus/library.py
+++ b/src/risk_atlas_nexus/library.py
@@ -12,6 +12,7 @@ from risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import (
     Action,
     Risk,
     RiskControl,
+    RiskIncident,
     RiskTaxonomy,
 )
 from risk_atlas_nexus.blocks.inference.templates import COT_TEMPLATE, AI_TASKS_TEMPLATE
@@ -382,7 +383,7 @@ class RiskAtlasNexus:
         return risk_detector.detect(usecases)
 
     def get_all_taxonomies(cls):
-        """Get all taxonomy definitions from the LinkML, optionally filtered by taxonomy
+        """Get all taxonomy definitions from the LinkML
 
         Returns:
             List[RiskTaxonomy]
@@ -624,3 +625,68 @@ class RiskAtlasNexus:
         )
 
         return risk_mapper.generate(new_risks=new_risks, existing_risks=existing_risks, inference_engine=inference_engine, new_prefix=new_prefix, mapping_method=mapping_method)
+
+
+    def get_risk_incidents(cls, taxonomy: Optional[str] = None):
+        """Get risk incident instances, optionally filtered by taxonomy
+
+        Returns:
+            List[RiskIncident]
+                Result containing a list of AI Risk Incidents
+        """
+        type_check("<RAN04811131E>", str, allow_none=True, taxonomy=taxonomy)
+
+        risk_incident_instances: List[RiskIncident] = cls._risk_explorer.get_risk_incidents(taxonomy=taxonomy)
+        return risk_incident_instances
+    
+    def get_risk_incident(cls, id=None, taxonomy=None):
+        """Get an risk incident instance filtered by risk incident id
+
+        Args:
+            id: str
+                The string id identifying the risk incident
+            taxonomy: str
+                (Optional) The string label for a taxonomy
+
+        Returns:
+            RiskIncident
+                Result containing a risk incident.
+        """
+        type_check("<RAN97353068E>", str, allow_none=False, id=id)
+        type_check("<RAN38198685E>", str, allow_none=True, taxonomy=taxonomy)
+
+        risk_incident: RiskIncident | None = cls._risk_explorer.get_risk_incident(id=id)
+        return risk_incident
+    
+    def get_related_risk_incidents(cls, risk=None, risk_id=None, taxonomy=None):
+        """Get related risk incident filtered by risk id
+
+        Args:
+            risk: (Optional) Risk
+                The risk
+            risk_id: (Optional) str
+                The string ID identifying the risk
+            taxonomy: str
+                (Optional) The string label for a taxonomy
+        Returns:
+            List[RiskIncident]
+                Result containing a list of AI risk incidents
+        """
+        type_check("<RAN40791379E>", Risk, allow_none=True, risk=risk)
+        type_check(
+            "<RANC9FDCC45E>",
+            str,
+            allow_none=True,
+            risk_id=risk_id,
+            taxonomy=taxonomy,
+        )
+        value_check(
+            "<RAN79007538E>",
+            risk or id,
+            "Please provide risk or id",
+        )
+
+        related_risk_incidents = cls._risk_explorer.get_related_risk_incidents(
+            risk=risk, risk_id=risk_id, taxonomy=taxonomy
+        )
+        return related_risk_incidents


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
- Add RiskIncident representation to the schema.  
- Update the library and explorer block to have methods for getting risk incidents
- Update Quickstart notebook 

Other changes:
- change some python `List` to `list`
- update a few docstrings
- update to mappings readme file


Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>

## Impacted Areas in Application
- Schema
- Documentation
- Knowledge graph content

## Which issue(s) does this pull-request fix?
<!-- Please include a link to the issue -->
<!-- Contributes to: IBM/risk-atlas-nexus# -->
<!-- Closes: IBM/risk-atlas-nexus# -->

## Any special notes for your reviewer?

--- 

## Checklist
- [ ] Automated tests exist
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local git lint performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided