### PR TITLE
enhancement: add separate entry for library documentation

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -36,7 +36,7 @@ nav:
       -  "Auto assist questionnaire" : examples/notebooks/autoassist_questionnaire.ipynb
   - Ontology:
       - Ontology: ontology/index.md
-      - "*"
+      - "ontology/*"
   - Python Reference:
-    - Python API:
-      - Risk Atlas Nexus: reference/index.md
+      - Library commands: reference/library_reference.md
+      - AI Risk Ontology: reference/ai_ontology_reference.md

--- a/docs/reference/ai_ontology_reference.md
+++ b/docs/reference/ai_ontology_reference.md
@@ -1,0 +1,23 @@
+# AI Risk Ontology documentation
+
+This is an automatic generated API reference of the main components of Risk Atlas Nexus
+
+::: risk_atlas_nexus.ai_risk_ontology
+    handler: python
+    options:
+        show_if_no_docstring: true
+        show_submodules: true
+        docstring_section_style: list
+        filters: ["!^_"]
+        heading_level: 2
+        inherited_members: true
+        merge_init_into_class: true
+        separate_signature: true
+        show_root_heading: true
+        show_root_full_path: false
+        show_signature_annotations: true
+        show_source: false
+        show_symbol_type_heading: true
+        show_symbol_type_toc: true
+        signature_crossrefs: true
+        summary: true

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,23 +1,3 @@
 # Risk Atlas Nexus
 
-This is an automatic generated API reference of the main components of Risk Atlas Nexus
-
-::: risk_atlas_nexus.ai_risk_ontology
-    handler: python
-    options:
-        show_if_no_docstring: true
-        show_submodules: true
-        docstring_section_style: list
-        filters: ["!^_"]
-        heading_level: 2
-        inherited_members: true
-        merge_init_into_class: true
-        separate_signature: true
-        show_root_heading: true
-        show_root_full_path: false
-        show_signature_annotations: true
-        show_source: false
-        show_symbol_type_heading: true
-        show_symbol_type_toc: true
-        signature_crossrefs: true
-        summary: true
+Automatically generated python documentation.

--- a/docs/reference/library_reference.md
+++ b/docs/reference/library_reference.md
@@ -1,0 +1,23 @@
+# Library convenience methods
+
+This is an automatic generated API reference of the library convenience methods for Risk Atlas Nexus
+
+::: risk_atlas_nexus.library
+    handler: python
+    options:
+        show_if_no_docstring: true
+        show_submodules: true
+        docstring_section_style: list
+        filters: ["!^_"]
+        heading_level: 2
+        inherited_members: true
+        merge_init_into_class: true
+        separate_signature: true
+        show_root_heading: true
+        show_root_full_path: false
+        show_signature_annotations: true
+        show_source: false
+        show_symbol_type_heading: true
+        show_symbol_type_toc: true
+        signature_crossrefs: true
+        summary: true


### PR DESCRIPTION
## Status
**READY**

## Description
Add a separate entry in the documentation site's auto-generated python API reference to highlight library methods as per Elizabeth's request.

Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>


## Impacted Areas in Application
- Generated documentation that would be visible at https://ibm.github.io/risk-atlas-nexus/reference/ 

### Screenshots
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/856ad834-4ef7-49f9-8fc2-f62bb847ddbe" />
