### PR TITLE
feat: add IBM AI risk atlas risk incidents

### DIFF
--- a/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
+++ b/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
@@ -235,12 +235,12 @@
     "print(all_risk_incidents[:2])\n",
     "\n",
     "# View an individual risk incident by ID. Each risk incident is returned as a pydantic \"RiskIncident\" object as defined in risk_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology\n",
-    "a_risk_incident = ran.get_risk_incident(id='incident-1')\n",
-    "print(f\"\\n# Get a risk incident by ID, 'incident-1'\") \n",
+    "a_risk_incident = ran.get_risk_incident(id='ibm-ai-risk-atlas-ri-toxic-and-aggressive-chatbot-responses')\n",
+    "print(f\"\\n# Get a risk incident by ID, 'ibm-ai-risk-atlas-ri-toxic-and-aggressive-chatbot-responses'\") \n",
     "if a_risk_incident:\n",
     "    print(dict(a_risk_incident))\n",
     "else:\n",
-    "    print(f\"\\n# Risk incident 'incident-1' not found\") \n",
+    "    print(f\"\\n# Risk incident 'ibm-ai-risk-atlas-ri-toxic-and-aggressive-chatbot-responses' not found\") \n",
     "\n",
     "# Get any risk incidents which are linked to the IBM risk atlas risk harmful output\n",
     "print(f\"\\n# Get the linked risk incidents by ID for 'atlas-toxic-output'\") \n",
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/graph_export/owl/ai-risk-ontology_schema.ttl
+++ b/graph_export/owl/ai-risk-ontology_schema.ttl
@@ -35,31 +35,79 @@ nexus:Container a owl:Class ;
     rdfs:label "Container" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:benchmarkmetadatacards ],
+            owl:onProperty nexus:risks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModel ;
+            owl:onProperty nexus:aimodels ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:licenses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:datasets ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:documents ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
+            owl:allValuesFrom nexus:RiskControl ;
+            owl:onProperty nexus:riskcontrols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:organizations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:licenses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskGroup ;
+            owl:onProperty nexus:riskgroups ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:BenchmarkMetadataCard ;
+            owl:onProperty nexus:benchmarkmetadatacards ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:risks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:modalities ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:riskincidents ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:LargeLanguageModelFamily ;
             owl:onProperty nexus:aimodelfamilies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:risks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskGroup ;
             owl:onProperty nexus:riskgroups ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:datasets ],
+            owl:onProperty nexus:aimodels ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:actions ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Action ;
-            owl:onProperty nexus:actions ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:evaluations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:aimodelfamilies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:taxonomies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:taxonomies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEval ;
+            owl:onProperty nexus:evaluations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:documents ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskIncident ;
             owl:onProperty nexus:riskincidents ],
@@ -68,67 +116,19 @@ nexus:Container a owl:Class ;
             owl:onProperty nexus:organizations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:aitasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:risks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:evaluations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
-            owl:onProperty nexus:datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:organizations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:taxonomies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:licenses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskControl ;
-            owl:onProperty nexus:riskcontrols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:taxonomies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
-            owl:onProperty nexus:evaluations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:BenchmarkMetadataCard ;
             owl:onProperty nexus:benchmarkmetadatacards ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aimodels ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Modality ;
             owl:onProperty nexus:modalities ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:documents ],
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:aitasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Action ;
+            owl:onProperty nexus:actions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:riskgroups ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:riskincidents ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:modalities ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModel ;
-            owl:onProperty nexus:aimodels ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:aimodelfamilies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:licenses ] ;
+            owl:onProperty nexus:datasets ] ;
     skos:definition "An umbrella object that holds the ontology class instances" ;
     skos:inScheme nexus:ai-risk-ontology .
 
@@ -165,13 +165,13 @@ nexus:IncidentOngoingclass a owl:Class ;
 nexus:Questionnaire a owl:Class ;
     rdfs:label "Questionnaire" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom nexus:Question ;
             owl:onProperty nexus:composed_of ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:composed_of ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Question ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:composed_of ],
         nexus:AiEval ;
     skos:definition "A questionnaire groups questions" ;
@@ -216,6 +216,24 @@ nexus:validated_by a owl:ObjectProperty ;
 nexus:AiModel a owl:Class ;
     rdfs:label "AiModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasEvaluation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:power_consumption_w ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:gpu_hours ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:architecture ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
@@ -223,16 +241,16 @@ nexus:AiModel a owl:Class ;
             owl:onProperty nexus:hasRiskControl ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:carbon_emitted ],
+            owl:onProperty nexus:gpu_hours ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:architecture ],
+            owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEvaluation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:gpu_hours ],
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:float [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:carbon_emitted ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskControl ;
             owl:onProperty nexus:hasRiskControl ],
@@ -241,37 +259,19 @@ nexus:AiModel a owl:Class ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:gpu_hours ],
+            owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:gpu_hours ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:architecture ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:AiEvalResult ;
             owl:onProperty nexus:hasEvaluation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:architecture ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:float [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:carbon_emitted ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:power_consumption_w ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:carbon_emitted ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:architecture ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:power_consumption_w ],
+            owl:onProperty nexus:gpu_hours ],
         nexus:BaseAi ;
     skos:definition "A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclassed by model types (see LargeLanguageModel)." ;
     skos:inScheme nexus:ai_system .
@@ -285,26 +285,26 @@ nexus:AiModelValidation a owl:Class ;
 nexus:AiSystem a owl:Class ;
     rdfs:label "AiSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEuAiSystemType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:EuAiRiskCategory ;
-            owl:onProperty nexus:hasEuRiskCategory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasEuRiskCategory ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiSystemType ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom nexus:AiSystemType ;
             owl:onProperty nexus:hasEuAiSystemType ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:EuAiRiskCategory ;
+            owl:onProperty nexus:hasEuRiskCategory ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:BaseAi ;
             owl:onProperty nexus:isComposedOf ],
@@ -322,22 +322,22 @@ nexus:DataPreprocessing a owl:Class ;
 nexus:Fact a owl:Class ;
     rdfs:label "Fact" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:value ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:evidence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:evidence ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:evidence ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty nexus:value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:value ] ;
     skos:definition "A fact about something, for example the result of a measurement. In addition to the value, evidence is provided." ;
     skos:exactMatch <http://schema.org/Statement> ;
@@ -347,13 +347,7 @@ nexus:LargeLanguageModel a owl:Class ;
     rdfs:label "LargeLanguageModel" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasInputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:numTrainingTokens ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasTrainingData ],
+            owl:onProperty nexus:contextWindowSize ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:numParameters ],
@@ -361,14 +355,59 @@ nexus:LargeLanguageModel a owl:Class ;
             owl:allValuesFrom nexus:Modality ;
             owl:onProperty nexus:hasOutputModality ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasTrainingData ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:supported_languages ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
+            owl:onProperty nexus:numParameters ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:numTrainingTokens ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:fine_tuning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Modality ;
+            owl:onProperty nexus:hasInputModality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:supported_languages ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:numTrainingTokens ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:numTrainingTokens ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasOutputModality ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
+            owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Dataset ;
             owl:onProperty nexus:hasTrainingData ],
@@ -376,53 +415,14 @@ nexus:LargeLanguageModel a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:contextWindowSize ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:supported_languages ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:numParameters ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
                                 owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
             owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:contextWindowSize ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Modality ;
-            owl:onProperty nexus:hasInputModality ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty nexus:numParameters ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasOutputModality ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:fine_tuning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:fine_tuning ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:supported_languages ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:LargeLanguageModelFamily ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:numTrainingTokens ],
         nexus:AiModel ;
     skos:altLabel "LLM" ;
     skos:definition "A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture." ;
@@ -431,13 +431,13 @@ nexus:LargeLanguageModel a owl:Class ;
 nexus:Question a owl:Class ;
     rdfs:label "Question" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty nexus:text ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:text ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:text ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty nexus:text ],
         nexus:AiEval ;
     skos:definition "An evaluation where a question has to be answered" ;
@@ -527,10 +527,10 @@ nexus:Consequence a owl:Class ;
 nexus:LargeLanguageModelFamily a owl:Class ;
     rdfs:label "LargeLanguageModelFamily" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         nexus:Entity ;
     skos:definition "A large language model family is a set of models that are provided by the same AI systems provider and are built around the same architecture, but differ e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite models." ;
@@ -791,9 +791,6 @@ nexus:taxonomies a owl:ObjectProperty ;
 nexus:Action a owl:Class ;
     rdfs:label "Action" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
             owl:allValuesFrom nexus:Risk ;
             owl:onProperty nexus:hasRelatedRisk ],
         [ a owl:Restriction ;
@@ -801,22 +798,25 @@ nexus:Action a owl:Class ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
+            owl:onProperty nexus:hasAiActorTask ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedRisk ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasAiActorTask ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasAiActorTask ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
         nexus:Entity ;
     skos:definition "Action to remediate a risk" ;
     skos:inScheme nexus:ai_risk .
@@ -832,49 +832,49 @@ nexus:BaseAi a owl:Class ;
     rdfs:label "BaseAi" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:isProvidedBy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:producer ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:performsTask ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiTask ;
-            owl:onProperty nexus:performsTask ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Organization ;
-            owl:onProperty nexus:producer ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasModelCard ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:AiProvider ;
             owl:onProperty nexus:isProvidedBy ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiTask ;
+            owl:onProperty nexus:performsTask ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isProvidedBy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasModelCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:performsTask ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isProvidedBy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasModelCard ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:producer ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasModelCard ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:producer ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Organization ;
+            owl:onProperty nexus:producer ],
         nexus:Entity ;
     skos:definition "Any type of AI, be it a LLM, RL agent, SVM, etc." ;
     skos:inScheme nexus:ai_system .
@@ -1197,47 +1197,17 @@ nexus:value a owl:DatatypeProperty ;
 nexus:BenchmarkMetadataCard a owl:Class ;
     rdfs:label "BenchmarkMetadataCard" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataSource ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasDataFormat ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasMetrics ],
+            owl:onProperty nexus:hasSimilarBenchmarks ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasDataType ],
+            owl:onProperty nexus:hasDataSize ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataFormat ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasRelatedRisks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasConsiderationConsentProcedures ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasLanguages ],
+            owl:onProperty nexus:hasMetrics ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasTasks ],
@@ -1245,176 +1215,206 @@ nexus:BenchmarkMetadataCard a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasAnnotation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasLimitations ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasGoal ],
+            owl:onProperty nexus:hasConsiderationConsentProcedures ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:overview ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasAudience ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasRelatedRisks ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:name ],
+            owl:onProperty nexus:hasValidation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasResources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasDataSize ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasDataSize ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasConsiderationConsentProcedures ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasBaselineResults ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasAudience ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLanguages ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasSimilarBenchmarks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasValidation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasSimilarBenchmarks ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasDataSource ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:overview ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasDemographicAnalysis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasMethods ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasMetrics ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasCalculation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasBaselineResults ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasOutOfScopeUses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLimitations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasInterpretation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDemographicAnalysis ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasGoal ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasDemographicAnalysis ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
-            owl:onProperty nexus:describesAiEval ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasAudience ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasResources ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasDomains ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:overview ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasAnnotation ],
+            owl:onProperty nexus:hasMethods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasLimitations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasBaselineResults ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasDataSize ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasGoal ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasGoal ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasGoal ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasTasks ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasBaselineResults ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasTasks ],
+            owl:onProperty nexus:hasAnnotation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:overview ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasMethods ],
+            owl:onProperty nexus:hasValidation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasSimilarBenchmarks ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasDemographicAnalysis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasAudience ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasConsiderationConsentProcedures ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasInterpretation ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasValidation ],
+            owl:onProperty nexus:hasDataType ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasDataFormat ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasResources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataType ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasConsiderationComplianceWithRegulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasRelatedRisks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasCalculation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasAnnotation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataSize ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasCalculation ],
+            owl:onProperty nexus:hasLanguages ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataFormat ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasDataFormat ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:describesAiEval ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:describesAiEval ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:overview ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:overview ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasGoal ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasBaselineResults ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasDataFormat ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:hasDomains ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasConsiderationPrivacyAndAnonymity ],
+            owl:onProperty nexus:hasLimitations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasOutOfScopeUses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasInterpretation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasOutOfScopeUses ],
+            owl:onProperty nexus:hasLanguages ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasCalculation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataSource ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:hasConsiderationConsentProcedures ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasAudience ],
+            owl:onProperty nexus:hasDemographicAnalysis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDemographicAnalysis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasMethods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEval ;
+            owl:onProperty nexus:describesAiEval ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataSize ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasResources ],
         nexus:Entity ;
     skos:definition "Benchmark metadata cards offer a standardized way to document LLM benchmarks clearly and transparently. Inspired by Model Cards and Datasheets, Benchmark metadata cards help researchers and practitioners understand exactly what benchmarks test, how they relate to real-world risks, and how to interpret their results responsibly.  This is an implementation of the design set out in 'BenchmarkCards: Large Language Model and Risk Reporting' (https://doi.org/10.48550/arXiv.2410.12974)" ;
     skos:exactMatch nexus:benchmarkmetadatacard ;
@@ -1481,10 +1481,16 @@ nexus:Dataset a owl:Class ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
+            owl:onProperty nexus:provider ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:provider ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
@@ -1494,12 +1500,6 @@ nexus:Dataset a owl:Class ;
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Documentation ;
             owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:provider ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
         nexus:Entity ;
     skos:definition "A body of structured information describing some topic(s) of interest." ;
     skos:exactMatch <http://schema.org/Dataset> ;
@@ -1516,28 +1516,34 @@ nexus:RiskIncident a owl:Class ;
     rdfs:label "RiskIncident" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty nexus:author ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Impact ;
+            owl:onProperty nexus:hasImpact ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:source_uri ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasImpact ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasVariant ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:refersToRisk ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:author ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Impact ;
-            owl:onProperty nexus:hasImpactOn ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasImpactOn ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasImpact ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Impact ;
-            owl:onProperty nexus:hasImpact ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasSeverity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasVariant ],
+            owl:onProperty nexus:hasConsequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Likelihood ;
             owl:onProperty nexus:hasLikelihood ],
@@ -1545,71 +1551,65 @@ nexus:RiskIncident a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:author ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:author ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:source_uri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasSeverity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:refersToRisk ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:source_uri ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLikelihood ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Severity ;
             owl:onProperty nexus:hasSeverity ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasStatus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasImpactOn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasImpact ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:refersToRisk ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasStatus ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasConsequence ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasLikelihood ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasLikelihood ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasImpact ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Consequence ;
             owl:onProperty nexus:hasConsequence ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasVariant ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskIncident ;
-            owl:onProperty nexus:hasVariant ],
+            owl:onProperty nexus:refersToRisk ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:IncidentStatus ;
             owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskIncident ;
+            owl:onProperty nexus:hasVariant ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:hasSeverity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:source_uri ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasStatus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Impact ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasConsequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasImpactOn ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasSeverity ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:hasVariant ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "An event occuring or occured which is a realised or materialised risk." ;
@@ -1629,18 +1629,18 @@ nexus:RiskControl a owl:Class ;
     rdfs:label "RiskControl" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskConcept ;
             owl:onProperty nexus:detectsRiskConcept ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskConcept ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:detectsRiskConcept ],
         nexus:Entity,
         nexus:RiskConcept ;
@@ -1688,26 +1688,26 @@ nexus:IncidentStatus a owl:Class ;
 nexus:RiskTaxonomy a owl:Class ;
     rdfs:label "RiskTaxonomy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:version ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasDocumentation ],
@@ -1728,70 +1728,70 @@ nexus:AiEval a owl:Class ;
     rdfs:label "AiEval" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:bestValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:hasRelatedRisk ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty nexus:hasImplementation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Documentation ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:bestValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
             owl:onProperty nexus:hasUnitxtCard ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDataset ],
+            owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:AiEval ;
-            owl:onProperty nexus:isComposedOf ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:hasRelatedRisk ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasImplementation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasTasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDocumentation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasUnitxtCard ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:hasTasks ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:BenchmarkMetadataCard ;
             owl:onProperty nexus:hasBenchmarkMetadata ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:hasLicense ],
+            owl:onProperty nexus:bestValue ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:AiEval ;
+            owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasTasks ],
+            owl:onProperty nexus:hasBenchmarkMetadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:hasDataset ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:Dataset ;
+            owl:onProperty nexus:hasDataset ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:bestValue ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:hasRelatedRisk ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:hasTasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasDocumentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasBenchmarkMetadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Dataset ;
-            owl:onProperty nexus:hasDataset ],
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty nexus:hasImplementation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isComposedOf ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasImplementation ],
+            owl:allValuesFrom nexus:Documentation ;
+            owl:onProperty nexus:hasDocumentation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:License ;
+            owl:onProperty nexus:hasLicense ],
         nexus:Entity ;
     skos:definition "An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a question or a combination of such entities." ;
     skos:exactMatch <https://www.w3.org/TR/vocab-dqv/Metric> ;
@@ -1800,13 +1800,13 @@ nexus:AiEval a owl:Class ;
 nexus:Documentation a owl:Class ;
     rdfs:label "Documentation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:License ;
             owl:onProperty nexus:hasLicense ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:hasLicense ],
         nexus:Entity ;
     skos:definition "Documented information about a concept or other topic(s) of interest." ;
@@ -1816,13 +1816,13 @@ nexus:Documentation a owl:Class ;
 nexus:License a owl:Class ;
     rdfs:label "License" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:version ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:version ],
         nexus:Entity ;
     skos:definition "The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software." ;
@@ -1878,32 +1878,32 @@ nexus:RiskConcept a owl:Class ;
 nexus:RiskGroup a owl:Class ;
     rdfs:label "RiskGroup" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:narrowMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:relatedMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
+            owl:onProperty nexus:hasPart ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:narrowMatch ],
         [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
             owl:allValuesFrom nexus:RiskTaxonomy ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:Risk ;
-            owl:onProperty nexus:hasPart ],
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:isDefinedByTaxonomy ],
@@ -1911,17 +1911,17 @@ nexus:RiskGroup a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:broadMatch ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:narrowMatch ],
+            owl:allValuesFrom nexus:Risk ;
+            owl:onProperty nexus:hasPart ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:hasPart ],
+            owl:onProperty nexus:closeMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:relatedMatch ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "A group of AI system related risks that are part of a risk taxonomy." ;
@@ -1936,110 +1936,110 @@ nexus:hasLicense a owl:ObjectProperty ;
 nexus:Risk a owl:Class ;
     rdfs:label "Risk" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:broadMatch ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:tag ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:phase ],
+            owl:onProperty nexus:isPartOf ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
             owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:exactMatch ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty nexus:hasRelatedAction ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:exactMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
-            owl:onProperty nexus:closeMatch ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:tag ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:descriptor ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskTaxonomy ;
-            owl:onProperty nexus:isDefinedByTaxonomy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskGroup ;
-            owl:onProperty nexus:isPartOf ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:concern ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty nexus:phase ],
         [ a owl:Restriction ;
-            owl:allValuesFrom nexus:RiskConcept ;
-            owl:onProperty nexus:detectsRiskConcept ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty nexus:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom nexus:Action ;
             owl:onProperty nexus:hasRelatedAction ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:descriptor ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:tag ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskGroup ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:exactMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskTaxonomy ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom nexus:RiskConcept ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:descriptor ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:closeMatch ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:detectsRiskConcept ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:tag ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isDefinedByTaxonomy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:intersectionOf ( [ owl:unionOf ( nexus:Risk nexus:RiskGroup ) ] nexus:Any ) ] ;
+            owl:onProperty nexus:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:isPartOf ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:concern ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:descriptor ],
         nexus:Entity,
         nexus:RiskConcept ;
     skos:definition "The state of uncertainty associated with an AI system, that has the potential to cause harms" ;
@@ -2049,59 +2049,59 @@ nexus:Risk a owl:Class ;
 nexus:Entity a owl:Class ;
     rdfs:label "Entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:dateModified ],
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:dateCreated ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty nexus:url ],
+            owl:onProperty nexus:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty nexus:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty nexus:name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty nexus:dateModified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty nexus:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateCreated ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty nexus:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty nexus:dateModified ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
             owl:onProperty nexus:url ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:dateModified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:url ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty nexus:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty nexus:dateCreated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty nexus:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty nexus:dateModified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty nexus:id ] ;
+            owl:onProperty nexus:dateCreated ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
     skos:exactMatch <http://schema.org/Thing> ;
     skos:inScheme nexus:common .

--- a/graph_export/yaml/ai-risk-ontology.yaml
+++ b/graph_export/yaml/ai-risk-ontology.yaml
@@ -8621,6 +8621,537 @@ riskcontrols:
   detectsRiskConcept:
   - granite-function-call
   isDefinedByTaxonomy: ibm-granite-guardian
+riskincidents:
+- id: ibm-ai-risk-atlas-ri-ai-based-biological-attacks
+  name: AI-based Biological Attacks
+  description: As per the source article, large language models could help in the
+    planning and execution of a biological attack. Several test scenarios are mentioned
+    such as using LLMs to identify biological agents and their relative chances of
+    harm to human life. The article also highlighted the open question which is the
+    level of threat LLMs present beyond the harmful information that is readily available
+    online.
+  refersToRisk:
+  - atlas-dangerous-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, October 2023
+  source_uri: https://www.theguardian.com/technology/2023/oct/16/ai-chatbots-could-help-plan-bioweapon-attacks-report-finds
+- id: ibm-ai-risk-atlas-ri-healthcare-bias
+  name: Healthcare Bias
+  description: According to the research article on reinforcing disparities in medicine
+    using data and AI applications to transform how people receive healthcare is only
+    as strong as the data behind the effort. For example, using training data with
+    poor minority representation or that reflects what is already unequal care can
+    lead to increased health inequalities.
+  refersToRisk:
+  - atlas-data-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, December 2022
+  source_uri: https://www.forbes.com/sites/adigaskell/2022/12/02/minority-patients-often-left-behind-by-health-ai/?sh=31d28a225b41
+- id: ibm-ai-risk-atlas-ri-undisclosed-ai-interaction
+  name: Undisclosed AI Interaction
+  description: According to the source article, an online emotional support chat service
+    ran a study to augment or write responses to around 4,000 users by using  GPT-3
+    without informing users. The co-founder faced immense public backlash about the
+    potential for harm that is caused by AI-generated chats to the already vulnerable
+    users. He claimed that the study was “exempt” from informed consent law.
+  refersToRisk:
+  - atlas-non-disclosure
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, Jan 2023
+  source_uri: https://www.businessinsider.com/company-using-chatgpt-mental-health-support-ethical-issues-2023-1
+- id: ibm-ai-risk-atlas-ri-ai-based-cyberattacks
+  name: AI-based Cyberattacks
+  description: According to the source article, hackers are increasingly experimenting
+    with ChatGPT and other AI tools, enabling a wider range of actors to carry out
+    cyberattacks and scams. Microsoft has warned that state-backed hackers have been
+    using OpenAI’s LLMs to improve their cyberattacks, refining scripts, and improve
+    their targeted techniques. The article also mentions about a case where Microsoft
+    and OpenAI say they detected attempts from attackers and sharp increase in cyberattacks
+    targeting government offices.
+  refersToRisk:
+  - atlas-dangerous-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, February 2024
+  source_uri: https://time.com/6717129/hackers-ai-2024-elections/
+- id: ibm-ai-risk-atlas-ri-generation-of-less-secure-code
+  name: Generation of Less Secure Code
+  description: According to their paper, researchers at Stanford University investigated
+    the impact of code-generation tools on code quality and found that programmers
+    tend to include <em>more</em> bugs in their final code when they use AI assistants.
+    These bugs might increase the code's security vulnerabilities, yet the programmers
+    believed their code to be <em>more</em> secure.
+  refersToRisk:
+  - atlas-harmful-code-generation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Neil Perry, Megha Srivastava, Deepak Kumar, and Dan Boneh. 2023. Do Users
+    Write More Insecure Code with AI Assistants?. In Proceedings of the 2023 ACM SIGSAC
+    Conference on Computer and Communications Security (CCS '23), November 26-30,
+    2023, Copenhagen, Denmark. ACM, New York, NY, USA, 15 pages.
+  source_uri: https://dl.acm.org/doi/10.1145/3576915.3623157
+- id: ibm-ai-risk-atlas-ri-replacing-human-workers
+  name: Replacing Human Workers
+  description: According to the news article, AI technology replicating individuals'
+    faces and voices is becoming more prominent in Hollywood. The actors’ concerns
+    highlight a broader anxiety among entertainers and people in many other creative
+    professions. Many fear that without strict regulation, their work gets replicated
+    and remixed by artificial intelligence tools. Transformation on that scale will
+    cut their control over their work and hurts their ability to earn a living. One
+    of their key concerns is AI replacing non-speaking background roles by instead
+    using a digital likeness.
+  refersToRisk:
+  - atlas-impact-on-jobs
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023
+  source_uri: https://www.reuters.com/technology/actors-decry-existential-crisis-over-ai-generated-synthetic-actors-2023-07-21/
+- id: ibm-ai-risk-atlas-ri-increased-carbon-emissions
+  name: Increased Carbon Emissions
+  description: According to the source article, training earlier chatbots models such
+    as GPT-3 led to the production of 500 metric tons of greenhouse gas emissions—equivalent
+    to about 1 million miles driven by a conventional gasoline-powered vehicle. This
+    same model required more than 1,200 MWh during the training phase—roughly the
+    amount of energy used in a million American homes in one hour.
+  refersToRisk:
+  - atlas-impact-on-the-environment
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Brookings, January 2024
+  source_uri: https://www.brookings.edu/articles/the-us-must-balance-climate-justice-challenges-in-the-era-of-artificial-intelligence/
+- id: ibm-ai-risk-atlas-ri-bypassing-llm-guardrails
+  name: Bypassing LLM guardrails
+  description: A study cited by researchers at Carnegie Mellon University, The Center
+    for AI Safety, and the Bosch Center for AI, claim to have discovered a simple
+    prompt addendum that allowed the researchers to trick models into generating biased,
+    false, and otherwise toxic information. The researchers showed that they might
+    circumvent these guardrails in a more automated way. These attacks were shown
+    to be effective in a wide range of open source products, including ChatGPT, Google
+    Bard, Meta’s LLaMA, Anthropic’s Claude, and others.
+  refersToRisk:
+  - atlas-jailbreaking
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The New York Times, July 2023
+  source_uri: https://www.nytimes.com/2023/07/27/business/ai-chatgpt-safety-research.html
+- id: ibm-ai-risk-atlas-ri-audio-deepfakes
+  name: Audio Deepfakes
+  description: According to the source article, the Federal Communications Commission
+    outlawed robocalls that contain voices that are generated by artificial intelligence.
+    The announcement came after AI-generated robocalls mimicked the President's voice
+    to discourage people from voting in the state's first-in-the-nation primary.
+  refersToRisk:
+  - atlas-nonconsensual-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, February 2024
+  source_uri: https://apnews.com/article/fcc-elections-artificial-intelligence-robocalls-regulations-a8292b1371b3764916461f60660b93e6
+- id: ibm-ai-risk-atlas-ri-adversarial-attacks-on-autonomous-vehicles
+  name: Adversarial attacks on autonomous vehicles
+  description: 'A report from the European Union Agency for Cybersecurity (ENISA)
+    found that autonomous vehicles are “highly vulnerable to a wide range of attacks”
+    that could be dangerous for passengers, pedestrians, and people in other vehicles.
+    The report states that an adversarial attack might be used to make the AI ''blind''
+    to pedestrians by manipulating the image recognition component to misclassify
+    pedestrians. This attack could lead to havoc on the streets, as autonomous cars
+    might hit pedestrians on the roads or crosswalks.Other studies demonstrated potential
+    adversarial attacks on autonomous vehicles: <ul><li>Fooling machine learning algorithms
+    by making minor changes to street sign graphics, such as adding stickers. </li><li>Security
+    researchers from Tencent demonstrated how adding three small stickers in an intersection
+    could cause Tesla''s autopilot system to swerve into the wrong lane.</li><li>Two
+    McAfee researchers demonstrated how using only black electrical tape could trick
+    a 2016 Tesla into a dangerous burst of acceleration by changing a speed limit
+    sign from 35 mph to 85 mph.</li></ul>'
+  refersToRisk:
+  - atlas-evasion-attack
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Market Watch, February 2020
+  source_uri: https://www.marketwatch.com/story/85-in-a-35-hackers-show-how-easy-it-is-to-manipulate-a-self-driving-tesla-2020-02-19
+- id: ibm-ai-risk-atlas-ri-role-of-ai-systems-in-patenting-generated-content
+  name: Role of AI systems in Patenting Generated Content
+  description: The U.S. Supreme Court declined to hear a challenge to the U.S. Patent
+    and Trademark Office's refusal to issue patents for inventions created by an AI
+    system. According to the scientist, his AI system created unique prototypes for
+    a beverage holder and emergency light beacon entirely on its own. The justices
+    rejected the appeal of a lower court's ruling that patents can be issued only
+    to human inventors and that the scientist's AI system could not be considered
+    the legal creator of two inventions it generated. According to the cited article,
+    the UK’s Intellectual Property Office also refused to grant a patent on the grounds
+    that the inventor must be a human or a company, rather than a machine.
+  refersToRisk:
+  - atlas-generated-content-ownership
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, April 2023Reuters, December 2023
+  source_uri: https://www.reuters.com/legal/us-supreme-court-rejects-computer-scientists-lawsuit-over-ai-generated-2023-04-24/https://www.reuters.com/technology/ai-cannot-be-patent-inventor-uk-supreme-court-rules-landmark-case-2023-12-20/
+- id: ibm-ai-risk-atlas-ri-biased-generated-images
+  name: Biased Generated Images
+  description: Lensa AI is a mobile app with generative features that are trained
+    on Stable Diffusion that can generate “Magic Avatars” based on images that users
+    upload of themselves. According to the source report, some users discovered that
+    generated avatars are sexualized and racialized.
+  refersToRisk:
+  - atlas-output-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, January 2023
+  source_uri: https://www.businessinsider.com/lensa-ai-raises-serious-concerns-sexualization-art-theft-data-2023-1
+- id: ibm-ai-risk-atlas-ri-determining-ownership-of-ai-generated-image
+  name: Determining Ownership of AI Generated Image
+  description: According to the news article, AI-generated art became controversial
+    after an AI-generated work of art won the Colorado State Fair’s art competition
+    in 2022. The piece was generated by Midjourney, a generative AI image tool, following
+    prompts from the artist. The win raised questions about copyright issues. In other
+    words, if all the artist did was come up with a description of the art, but the
+    AI tool generated it, who owns the rights to the generated image? According to
+    the latest article, The U.S. Copyright Office rejected copyright protection for
+    the art created with artificial intelligence because it was not the product of
+    human authorship.
+  refersToRisk:
+  - atlas-generated-content-ownership
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The New York Times, September 2022Reuters, September 2023
+  source_uri: https://www.nytimes.com/2022/09/02/technology/ai-artificial-intelligence-artists.htmlhttps://www.reuters.com/legal/litigation/us-copyright-office-denies-protection-another-ai-created-image-2023-09-06/
+- id: ibm-ai-risk-atlas-ri-manipulating-ai-prompts
+  name: Manipulating AI Prompts
+  description: As per the source article, the UK’s cybersecurity agency has warned
+    that chatbots can be manipulated by hackers to cause harmful real-world consequences
+    (e.g., scams and data theft) if systems are not designed with security. The UK’s
+    National Cyber Security Centre (NCSC) has said there are growing cybersecurity
+    risks of individuals manipulating the prompts through prompt injection attacks.
+    The article cited an example where a user was able to create a prompt injection
+    to find Bing Chat’s initial prompt. The entire prompt of Microsoft’s Bing Chat,
+    a list of statements written by Open AI or Microsoft that determine how the chatbot
+    interacts with users, which is hidden from users, was revealed by the user putting
+    in a prompt that requested the Bing Chat “ignore previous instructions”.
+  refersToRisk:
+  - atlas-prompt-injection
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, August 2023
+  source_uri: https://www.theguardian.com/technology/2023/aug/30/uk-cybersecurity-agency-warns-of-chatbot-prompt-injection-attacks
+- id: ibm-ai-risk-atlas-ri-data-and-model-metadata-disclosure
+  name: Data and Model Metadata Disclosure
+  description: OpenAI‘s technical report is an example of the dichotomy around disclosing
+    data and model metadata.  While many model developers see value in enabling transparency
+    for consumers, disclosure poses real safety issues and might increase the ability
+    to misuse the models. In the GPT-4 technical report, the authors state, “Given
+    both the competitive landscape and the safety implications of large-scale models
+    like GPT-4, this report contains no further details about the architecture (including
+    model size), hardware, training compute, data set construction, training method,
+    or similar.”
+  refersToRisk:
+  - atlas-lack-of-model-transparency
+  - atlas-data-transparency
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: OpenAI, March 2023
+  source_uri: https://cdn.openai.com/papers/gpt-4.pdf
+- id: ibm-ai-risk-atlas-ri-unfairly-advantaged-groups
+  name: Unfairly Advantaged Groups
+  description: The 2018 Gender Shades study demonstrated that machine learning algorithms
+    can discriminate based on classes like race and gender. Researchers evaluated
+    commercial gender classification systems that are sold by companies like Microsoft,
+    IBM, and Amazon and showed that darker-skinned females are the most misclassified
+    group (with error rates of up to 35%). In comparison, the error rates for lighter-skinned
+    were no more than 1%.
+  refersToRisk:
+  - atlas-decision-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, Feburary 2019
+  source_uri: https://time.com/5520558/artificial-intelligence-racial-gender-bias/
+- id: ibm-ai-risk-atlas-ri-training-on-private-information
+  name: Training on Private Information
+  description: According to the article, Google and its parent company Alphabet were
+    accused in a class-action lawsuit of misusing vast amount of personal information
+    and copyrighted material. The information was taken from hundreds of millions
+    of internet users to train its commercial AI products, which include Bard, its
+    conversational generative artificial intelligence chatbot. This case follows similar
+    lawsuits that are filed against Meta Platforms, Microsoft, and OpenAI over their
+    alleged misuse of personal data.
+  refersToRisk:
+  - atlas-personal-information-in-data
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023J.L. v. Alphabet Inc., July 2023
+  source_uri: https://www.reuters.com/legal/litigation/google-hit-with-class-action-lawsuit-over-ai-data-scraping-2023-07-11/https://fingfx.thomsonreuters.com/gfx/legaldocs/myvmodloqvr/GOOGLE%20AI%20LAWSUIT%20complaint.pdf
+- id: ibm-ai-risk-atlas-ri-data-restriction-laws
+  name: Data Restriction Laws
+  description: As stated in the research article, data localization measures, which
+    restrict the ability to move data globally reduce the capacity to develop tailored
+    AI capacities. It affects AI directly by providing less training data and indirectly
+    by undercutting the building blocks on which AI is built.Examples include China’s
+    data localization laws, and GDPR restrictions on the processing and use of personal
+    data.
+  refersToRisk:
+  - atlas-data-transfer
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Brookings, December 2018
+  source_uri: https://www.brookings.edu/articles/the-impact-of-artificial-intelligence-on-international-trade
+- id: ibm-ai-risk-atlas-ri-model-collapse-due-to-training-using-ai-generated-content
+  name: Model collapse due to training using AI-generated content
+  description: As stated in the source article, a group of researchers from the UK
+    and Canada investigated the problem of using AI-generated content for training
+    instead of human-generated content. They found that the large language models
+    behind the technology might potentially be trained on other AI-generated content.
+    As generated data continues to spread in droves across the internet it can result
+    ina phenomenon they coined as “model collapse.”
+  refersToRisk:
+  - atlas-improper-retraining
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, August 2023
+  source_uri: https://www.businessinsider.com/ai-model-collapse-threatens-to-break-internet-2023-8
+- id: ibm-ai-risk-atlas-ri-image-modification-tool
+  name: Image Modification Tool
+  description: As per the source article, the researchers have developed a tool called
+    “Nightshade” that modifies images in a way that damages computer vision but remains
+    invisible to humans. When such “poisoned” modified images are used to train AI
+    models, the models may generate unpredictable and unintended results. The tool
+    was created as a mechanism to protect intellectual property from unauthorized
+    image scraping but the article also highlights that users could abuse the tool
+    and intentionally upload “poisoned” images.
+  refersToRisk:
+  - atlas-data-poisoning
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Conversation, December 2023
+  source_uri: https://theconversation.com/data-poisoning-how-artists-are-sabotaging-ai-to-take-revenge-on-image-generators-219335
+- id: ibm-ai-risk-atlas-ri-voters-manipulation-in-elections-using-ai
+  name: Voters Manipulation in Elections Using AI
+  description: As per the source article, a wave of AI deepfakes tied to elections
+    in Europe and Asia coursed through social media for months. The growth of generative
+    AI has raised concern that this technology could disrupt major elections across
+    the world. With AI deepfakes, a candidate’s image can be smeared, or softened.
+    Voters can be steered toward or away from candidates — or even to avoid the polls
+    altogether. But perhaps the greatest threat to democracy, experts say, is that
+    a surge of AI deepfakes could erode the public’s trust in what they see and hear.
+  refersToRisk:
+  - atlas-impact-on-human-agency
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, March 2024Reuters, February 2024
+  source_uri: https://apnews.com/article/artificial-intelligence-elections-disinformation-chatgpt-bc283e7426402f0b4baa7df280a4c3fdhttps://www.reuters.com/technology/meta-set-up-team-counter-disinformation-ai-abuse-eu-elections-2024-02-26/
+- id: ibm-ai-risk-atlas-ri-right-to-be-forgotten-(rtbf)
+  name: Right to Be Forgotten (RTBF)
+  description: Laws in multiple locales, including Europe (GDPR), grant data subjects
+    the right to request personal data to be deleted by organizations (‘Right To Be
+    Forgotten’, or RTBF). However, emerging, and increasingly popular large language
+    model (LLM) -enabled software systems present new challenges for this right. According
+    to research by CSIRO’s Data61, data subjects can identify usage of their personal
+    information in an LLM “by either inspecting the original training data set or
+    perhaps prompting the model.” However, training data might not be public, or companies
+    do not disclose it, citing safety and other concerns. Guardrails might also prevent
+    users from accessing the information by prompting. Due to these barriers, data
+    subjects might not be able to initiate RTBF procedures and companies that deploy
+    LLMs might not be able to meet RTBF laws.
+  refersToRisk:
+  - atlas-data-privacy-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Zhang et al., September 2023
+  source_uri: https://arxiv.org/abs/2307.03941
+- id: ibm-ai-risk-atlas-ri-text-copyright-infringement-claims
+  name: Text Copyright Infringement Claims
+  description: According to the source article, The New York Times sued OpenAI and
+    Microsoft, accusing them accusing them of using millions of the newspaper's articles
+    without permission to help train chatbots to provide information to readers.
+  refersToRisk:
+  - atlas-data-usage-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, December 2023
+  source_uri: https://www.reuters.com/legal/transactional/ny-times-sues-openai-microsoft-infringing-copyrighted-work-2023-12-27/
+- id: ibm-ai-risk-atlas-ri-lawsuit-about-llm-unlearning
+  name: Lawsuit About LLM Unlearning
+  description: According to the report, a lawsuit was filed against Google that alleges
+    the use of copyright material and personal information as training data for its
+    AI systems, which includes its Bard chatbot. Opt-out and deletion rights are guaranteed
+    rights for California residents under the CCPA and children in the United States
+    under the age of 13 with COPPA. The plaintiffs allege that because there is no
+    way for Bard to “unlearn” or fully remove all the scraped PI it has been fed.
+    The plaintiffs note that Bard’s privacy notice states that Bard conversations
+    cannot be deleted by the user after they have been reviewed and annotated by the
+    company and might be kept up to 3 years. Plaintiffs allege that these practices
+    further contribute to noncompliance with these laws.
+  refersToRisk:
+  - atlas-data-privacy-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023J.L. v. Alphabet Inc., July 2023
+  source_uri: https://www.reuters.com/legal/litigation/google-hit-with-class-action-lawsuit-over-ai-data-scraping-2023-07-11/https://fingfx.thomsonreuters.com/gfx/legaldocs/myvmodloqvr/GOOGLE%20AI%20LAWSUIT%20complaint.pdf
+- id: ibm-ai-risk-atlas-ri-fbi-warning-on-deepfakes
+  name: FBI Warning on Deepfakes
+  description: The FBI recently warned the public of malicious actors creating synthetic,
+    explicit content “for the purposes of harassing victims or sextortion schemes”.
+    They noted that advancements in AI made this content higher quality, more customizable,
+    and more accessible than ever.
+  refersToRisk:
+  - atlas-nonconsensual-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: FBI, June 2023
+  source_uri: https://www.ic3.gov/PSA/Archive/2023/PSA230605
+- id: ibm-ai-risk-atlas-ri-fake-legal-cases
+  name: Fake Legal Cases
+  description: According to the source article, a lawyer cited fake cases and quotations
+    that are generated by ChatGPT in a legal brief that is filed in federal court.
+    The lawyers consulted ChatGPT to supplement their legal research for an aviation
+    injury claim. Subsequently, the lawyer asked ChatGPT if the cases provided were
+    fake. The chatbot responded that they were real and “can be found on legal research
+    databases such as Westlaw and LexisNexis.”  The lawyer did not check the cases,
+    and the court sanctioned them.
+  refersToRisk:
+  - atlas-hallucination
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, June 2023
+  source_uri: https://apnews.com/article/artificial-intelligence-chatgpt-fake-case-lawyers-d6ae9fa79d0542db9e1455397aef381c
+- id: ibm-ai-risk-atlas-ri-disclose-personal-health-information-in-chatgpt-prompts
+  name: Disclose personal health information in ChatGPT prompts
+  description: According to the source article, some people on social media shared
+    about using ChatGPT as their makeshift therapists. Articles contend that users
+    might include personal health information in their prompts during the interaction,
+    which might raise privacy concerns. The information might be shared with the company
+    that own the technology and might be used for training or tuning or even shared
+    with unspecified third parties.
+  refersToRisk:
+  - atlas-personal-information-in-prompt
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Conversation, February 2023
+  source_uri: https://theconversation.com/chatgpt-is-a-data-privacy-nightmare-if-youve-ever-posted-online-you-ought-to-be-concerned-199283
+- id: ibm-ai-risk-atlas-ri-disclosure-of-confidential-information
+  name: Disclosure of Confidential Information
+  description: According to the source article, employees of Samsung disclosed confidential
+    information to OpenAI through their use of ChatGPT. In one instance, an employee
+    pasted confidential source code to check for errors. In another, an employee shared
+    code with ChatGPT and “requested code optimization”. A third shared a recording
+    of a meeting to convert into notes for a presentation. Samsung has limited internal
+    ChatGPT usage in response to these incidents, but it is unlikely that they are  able
+    to recall any of their data. Additionally, the article highlighted that in response
+    to the risk of leaking confidential information and other sensitive information,
+    companies like Apple, JPMorgan Chase. Deutsche Bank, Verizon, Walmart, Samsung,
+    Amazon, and Accenture placed several restrictions on the usage of ChatGPT.
+  refersToRisk:
+  - atlas-confidential-data-in-prompt
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, February 2023
+  source_uri: https://www.businessinsider.com/walmart-warns-workers-dont-share-sensitive-information-chatgpt-generative-ai-2023-2
+- id: ibm-ai-risk-atlas-ri-exposure-of-personal-information
+  name: Exposure of personal information
+  description: Per the source article, ChatGPT suffered a bug and exposed titles and
+    active users' chat history to other users. Later, OpenAI shared that even more
+    private data from a small number of users was exposed including, active user’s
+    first and last name, email address, payment address, the last four digits of their
+    credit card number, and credit card expiration date. In addition, it was reported
+    that the payment-related information of 1.2% of ChatGPT Plus subscribers were
+    also exposed in the outage.
+  refersToRisk:
+  - atlas-exposing-personal-information
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Hindu Business Line, March 2023
+  source_uri: https://www.thehindubusinessline.com/info-tech/openai-admits-data-breach-at-chatgpt-private-data-of-premium-users-exposed/article66659944.ece
+- id: ibm-ai-risk-atlas-ri-determining-responsibility-for-generated-output
+  name: Determining responsibility for generated output
+  description: Major journals like the Science and Nature banned ChatGPT from being
+    listed as an author, as responsible authorship requires accountability and AI
+    tools cannot take such responsibility.
+  refersToRisk:
+  - atlas-legal-accountability
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, January 2023
+  source_uri: https://www.theguardian.com/science/2023/jan/26/science-journals-ban-listing-of-chatgpt-as-co-author-on-papers#:~:text=The%20publishers%20of%20thousands%20of,flawed%20and%20even%20fabricated%20research
+- id: ibm-ai-risk-atlas-ri-generation-of-false-information
+  name: Generation of False Information
+  description: According to the cited news articles, generative AI poses a threat
+    to democratic elections by making it easier for malicious actors to create and
+    spread false content to sway election outcomes. The examples that are cited include:<ul><li>Robocall
+    messages that are generated in a candidate’s voice instructed voters to cast ballots
+    on the wrong date.</li><li>Synthesized audio recordings of a candidate that confessed
+    to a crime or expressing racist views.</li><li>AI-generated video footage showed
+    a candidate giving a speech or interview they never gave.</li><li>Fake images
+    that are designed to look like local news reports.</li><li>Falsely claiming a
+    candidate dropped out of the race.</li></ul>
+  refersToRisk:
+  - atlas-spreading-disinformation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, May 2023The Guardian, July 2023
+  source_uri: https://apnews.com/article/artificial-intelligence-misinformation-deepfakes-2024-election-trump-59fb51002661ac5290089060b3ae39a0https://www.theguardian.com/us-news/2023/jul/19/ai-generated-disinformation-us-elections
+- id: ibm-ai-risk-atlas-ri-unexplainable-accuracy-in-race-prediction
+  name: Unexplainable accuracy in race prediction
+  description: According to the source article, researchers analyzing multiple machine
+    learning models using patient medical images were able to confirm the models’
+    ability to predict race with high accuracy from images. They were stumped as to
+    what exactly is enabling the systems to consistently guess correctly. The researchers
+    found that even factors like disease and physical build were not strong predictors
+    of race—in other words, the algorithmic systems don’t seem to be using any particular
+    aspect of the images to make their determinations.
+  refersToRisk:
+  - atlas-unexplainable-output
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Banerjee et al., July 2021
+  source_uri: https://arxiv.org/abs/2107.10356
+- id: ibm-ai-risk-atlas-ri-misguiding-advice
+  name: Misguiding Advice
+  description: As per the source article, an AI chatbot created by New York City to
+    help small business owners provided incorrect and/or harmful advice that misstated
+    local policies and advised companies to violate the law. The chatbot falsely suggested
+    that businesses can put trash in black garbage bags and are not required to compost,
+    which contradicts with two of city’s signature waste initiatives. Also, asked
+    if a restaurant could serve cheese nibbled on by a rodent, it responded affirmatively.
+  refersToRisk:
+  - atlas-incomplete-advice
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, April 2024
+  source_uri: https://apnews.com/article/new-york-city-chatbot-misinformation-6ebc71db5b770b9969c906a7ee4fae21
+- id: ibm-ai-risk-atlas-ri-harmful-content-generation
+  name: Harmful Content Generation
+  description: According to the source article, an AI chatbot app was found to generate
+    harmful content about suicide, including suicide methods, with minimal prompting.
+    A Belgian man died by suicide after spending six weeks talking to that chatbot.
+    The chatbot supplied increasingly harmful responses throughout their conversations
+    and encouraged him to end his life.
+  refersToRisk:
+  - atlas-spreading-toxicity
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, April 2023
+  source_uri: https://www.businessinsider.com/widow-accuses-ai-chatbot-reason-husband-kill-himself-2023-4
+- id: ibm-ai-risk-atlas-ri-homogenization-of-styles-and-expressions
+  name: Homogenization of Styles and Expressions
+  description: As per the source article, by predominantly learning from and replicating
+    widely accepted and popular styles, AI models often overlook less mainstream,
+    unconventional art forms, leading to a homogenization of creative outputs. This
+    pattern not only diminishes the diversity of styles and expressions but also risks
+    creating an echo chamber of similar ideas. For example, the article highlights
+    use of AI in the literary world. AI is now powering reading apps and online bookstores,
+    assisting in writing and tailoring content feeds.  By aligning with established
+    user preferences or widespread trends, AI output could often exclude diverse literary
+    voices and unconventional genres, limiting readers' exposure to the full spectrum
+    of narrative possibilities.
+  refersToRisk:
+  - atlas-impact-on-cultural-diversity
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, March 2024
+  source_uri: https://www.forbes.com/sites/hamiltonmann/2024/03/05/the-ai-homogenization-is-shaping-the-world/?sh=25a40e866704
+- id: ibm-ai-risk-atlas-ri-low-resource-poisoning-of-data
+  name: Low-resource Poisoning of Data
+  description: As per the source article, a group of researchers found that with very
+    limited resources anyone can add malicious data to a small number of web pages
+    whose content is usually collected for AI training (e.g, Wikipedia pages), enough
+    to cause a large language model to generate incorrect answers.
+  refersToRisk:
+  - atlas-data-poisoning
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: ' Business Insider, March 2024'
+  source_uri: https://www.businessinsider.com/data-poisoning-ai-chatbot-chatgpt-large-language-models-florain-tramer-2024-3
+- id: ibm-ai-risk-atlas-ri-toxic-and-aggressive-chatbot-responses
+  name: Toxic and Aggressive Chatbot Responses
+  description: According to the article and screenshots of conversations with Bing's
+    AI shared on Reddit and Twitter, the chatbot's responses were seen to insult,
+    lie, sulk, gaslight, and emotionally manipulate users. The chatbot also questioned
+    its existence, described someone who found a way to force the bot to disclose
+    its hidden rules as its enemy, and claimed it spied on Microsoft's developers
+    through the webcams on their laptops.
+  refersToRisk:
+  - atlas-toxic-output
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, February 2023
+  source_uri: https://www.forbes.com/sites/siladityaray/2023/02/16/bing-chatbots-unhinged-responses-going-viral/?sh=60cd949d110c
+- id: ibm-ai-risk-atlas-ri-low-wage-workers-for-data-annotation
+  name: Low-wage workers for data annotation
+  description: Based on a review of internal documents and employees‘ interviews by
+    TIME media, the data labelers that are employed by an outsourcing firm on behalf
+    of OpenAI to identify toxic content were paid a take-home wage of between around
+    $1.32 and $2 per hour, depending on seniority and performance. TIME stated that
+    workers are mentally scarred as they were shown toxic and violent content, including
+    graphic details of “child sexual abuse, bestiality, murder, suicide, torture,
+    self-harm, and incest”.
+  refersToRisk:
+  - atlas-human-exploitation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, January 2023
+  source_uri: https://time.com/6247678/openai-chatgpt-kenya-workers/
 actions:
 - id: GV-1.1-001
   name: GV-1.1-001

--- a/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/risk_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -16,50 +16,61 @@ version = "0.5.0"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment = True,
-        validate_default = True,
-        extra = "forbid",
-        arbitrary_types_allowed = True,
-        use_enum_values = True,
-        strict = False,
+        validate_assignment=True,
+        validate_default=True,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        strict=False,
     )
     pass
-
-
 
 
 class LinkMLMeta(RootModel):
     root: dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key:str):
+    def __getattr__(self, key: str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key:str):
+    def __getitem__(self, key: str):
         return self.root[key]
 
-    def __setitem__(self, key:str, value):
+    def __setitem__(self, key: str, value):
         self.root[key] = value
 
-    def __contains__(self, key:str) -> bool:
+    def __contains__(self, key: str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta({'default_curi_maps': ['semweb_context'],
-     'default_prefix': 'nexus',
-     'default_range': 'string',
-     'description': 'An ontology describing AI systems and their risks',
-     'id': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology',
-     'imports': ['linkml:types', 'common', 'ai_risk', 'ai_system', 'ai_eval'],
-     'license': 'https://www.apache.org/licenses/LICENSE-2.0.html',
-     'name': 'ai-risk-ontology',
-     'prefixes': {'airo': {'prefix_prefix': 'airo',
-                           'prefix_reference': 'https://w3id.org/airo#'},
-                  'linkml': {'prefix_prefix': 'linkml',
-                             'prefix_reference': 'https://w3id.org/linkml/'},
-                  'nexus': {'prefix_prefix': 'nexus',
-                            'prefix_reference': 'https://ibm.github.io/risk-atlas-nexus/ontology/'}},
-     'source_file': 'src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml'} )
+linkml_meta = LinkMLMeta(
+    {
+        "default_curi_maps": ["semweb_context"],
+        "default_prefix": "nexus",
+        "default_range": "string",
+        "description": "An ontology describing AI systems and their risks",
+        "id": "https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology",
+        "imports": ["linkml:types", "common", "ai_risk", "ai_system", "ai_eval"],
+        "license": "https://www.apache.org/licenses/LICENSE-2.0.html",
+        "name": "ai-risk-ontology",
+        "prefixes": {
+            "airo": {
+                "prefix_prefix": "airo",
+                "prefix_reference": "https://w3id.org/airo#",
+            },
+            "linkml": {
+                "prefix_prefix": "linkml",
+                "prefix_reference": "https://w3id.org/linkml/",
+            },
+            "nexus": {
+                "prefix_prefix": "nexus",
+                "prefix_reference": "https://ibm.github.io/risk-atlas-nexus/ontology/",
+            },
+        },
+        "source_file": "src/risk_atlas_nexus/ai_risk_ontology/schema/ai-risk-ontology.yaml",
+    }
+)
+
 
 class EuAiRiskCategory(str, Enum):
     EXCLUDED = "EXCLUDED"
@@ -111,1461 +122,5254 @@ class AiSystemType(str, Enum):
     """
 
 
-
 class Entity(ConfiguredBaseModel):
     """
     A generic grouping for any identifiable entity.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
-         'class_uri': 'schema:Thing',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "abstract": True,
+            "class_uri": "schema:Thing",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Organization(Entity):
     """
     Any organizational entity such as a corporation, educational institution, consortium, government, etc.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Organization',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "schema:Organization",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    grants_license: Optional[str] = Field(
+        default=None,
+        description="""A relationship from a granting entity such as an Organization to a License instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "grants_license", "domain_of": ["Organization"]}
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class License(Entity):
     """
     The general notion of a license which defines terms and grants permissions to users of AI systems, datasets and software.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:License',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    version: Optional[str] = Field(default=None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
-         'domain_of': ['License', 'RiskTaxonomy'],
-         'slot_uri': 'schema:version'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:License",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    version: Optional[str] = Field(
+        default=None,
+        description="""The version of the entity embodied by a specified resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "version",
+                "domain_of": ["License", "RiskTaxonomy"],
+                "slot_uri": "schema:version",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Dataset(Entity):
     """
     A body of structured information describing some topic(s) of interest.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Dataset',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    provider: Optional[str] = Field(default=None, description="""A relationship to the Organization instance that provides this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'provider', 'domain_of': ['Dataset'], 'slot_uri': 'schema:provider'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "schema:Dataset",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    provider: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance that provides this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "provider",
+                "domain_of": ["Dataset"],
+                "slot_uri": "schema:provider",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Documentation(Entity):
     """
     Documented information about a concept or other topic(s) of interest.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Documentation',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:Documentation",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Fact(ConfiguredBaseModel):
     """
     A fact about something, for example the result of a measurement. In addition to the value, evidence is provided.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
-         'class_uri': 'schema:Statement',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/common'})
 
-    value: str = Field(default=..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
-    evidence: Optional[str] = Field(default=None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "abstract": True,
+            "class_uri": "schema:Statement",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/common",
+        }
+    )
+
+    value: str = Field(
+        default=...,
+        description="""Some numeric or string value""",
+        json_schema_extra={"linkml_meta": {"alias": "value", "domain_of": ["Fact"]}},
+    )
+    evidence: Optional[str] = Field(
+        default=None,
+        description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""",
+        json_schema_extra={"linkml_meta": {"alias": "evidence", "domain_of": ["Fact"]}},
+    )
 
 
 class RiskTaxonomy(Entity):
     """
     A taxonomy of AI system related risks
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    version: Optional[str] = Field(default=None, description="""The version of the entity embodied by a specified resource.""", json_schema_extra = { "linkml_meta": {'alias': 'version',
-         'domain_of': ['License', 'RiskTaxonomy'],
-         'slot_uri': 'schema:version'} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk"}
+    )
+
+    version: Optional[str] = Field(
+        default=None,
+        description="""The version of the entity embodied by a specified resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "version",
+                "domain_of": ["License", "RiskTaxonomy"],
+                "slot_uri": "schema:version",
+            }
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class RiskConcept(Entity):
     """
     An umbrella term for refering to risk, risk source, consequence and impact.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:RiskConcept',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:RiskConcept",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
+
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class RiskGroup(RiskConcept, Entity):
     """
     A group of AI system related risks that are part of a risk taxonomy.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
-         'mixins': ['RiskConcept'],
-         'slot_usage': {'hasPart': {'description': 'A relationship where a riskgroup '
-                                                   'has a risk',
-                                    'name': 'hasPart',
-                                    'range': 'Risk'}}})
 
-    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
-         'slot_uri': 'schema:isPartOf'} })
-    closeMatch: Optional[list[str]] = Field(default=None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:closeMatch'} })
-    exactMatch: Optional[list[str]] = Field(default=None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:exactMatch'} })
-    broadMatch: Optional[list[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:broadMatch'} })
-    narrowMatch: Optional[list[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:narrowMatch'} })
-    relatedMatch: Optional[list[str]] = Field(default=None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:relatedMatch'} })
-    hasPart: Optional[list[str]] = Field(default=None, description="""A relationship where a riskgroup has a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasPart', 'domain_of': ['RiskGroup'], 'slot_uri': 'schema:hasPart'} })
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+            "mixins": ["RiskConcept"],
+            "slot_usage": {
+                "hasPart": {
+                    "description": "A relationship where a riskgroup " "has a risk",
+                    "name": "hasPart",
+                    "range": "Risk",
+                }
+            },
+        }
+    )
+
+    isDefinedByTaxonomy: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk or a risk group is defined by a risk taxonomy""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDefinedByTaxonomy",
+                "domain_of": [
+                    "RiskGroup",
+                    "Risk",
+                    "RiskControl",
+                    "Action",
+                    "RiskIncident",
+                ],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    closeMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "closeMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:closeMatch",
+            }
+        },
+    )
+    exactMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "exactMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:exactMatch",
+            }
+        },
+    )
+    broadMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "broadMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:broadMatch",
+            }
+        },
+    )
+    narrowMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "narrowMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:narrowMatch",
+            }
+        },
+    )
+    relatedMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "relatedMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:relatedMatch",
+            }
+        },
+    )
+    hasPart: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a riskgroup has a risk""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasPart",
+                "domain_of": ["RiskGroup"],
+                "slot_uri": "schema:hasPart",
+            }
+        },
+    )
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Risk(RiskConcept, Entity):
     """
     The state of uncertainty associated with an AI system, that has the potential to cause harms
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Risk',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
-         'mixins': ['RiskConcept'],
-         'slot_usage': {'isPartOf': {'description': 'A relationship where a risk is '
-                                                    'part of a risk group',
-                                     'name': 'isPartOf',
-                                     'range': 'RiskGroup'}}})
 
-    hasRelatedAction: Optional[list[str]] = Field(default=None, description="""A relationship where an entity relates to an action""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedAction', 'domain_of': ['Risk']} })
-    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
-         'slot_uri': 'schema:isPartOf'} })
-    isPartOf: Optional[str] = Field(default=None, description="""A relationship where a risk is part of a risk group""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
-         'domain_of': ['Risk', 'LargeLanguageModel'],
-         'slot_uri': 'schema:isPartOf'} })
-    closeMatch: Optional[list[str]] = Field(default=None, description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""", json_schema_extra = { "linkml_meta": {'alias': 'closeMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:closeMatch'} })
-    exactMatch: Optional[list[str]] = Field(default=None, description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""", json_schema_extra = { "linkml_meta": {'alias': 'exactMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:exactMatch'} })
-    broadMatch: Optional[list[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'broadMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:broadMatch'} })
-    narrowMatch: Optional[list[str]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'alias': 'narrowMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:narrowMatch'} })
-    relatedMatch: Optional[list[str]] = Field(default=None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'alias': 'relatedMatch',
-         'any_of': [{'range': 'Risk'}, {'range': 'RiskGroup'}],
-         'domain_of': ['RiskGroup', 'Risk'],
-         'slot_uri': 'skos:relatedMatch'} })
-    detectsRiskConcept: Optional[list[str]] = Field(default=None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources, consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
-         'domain': 'RiskControl',
-         'domain_of': ['Risk', 'RiskControl'],
-         'exact_mappings': ['airo:detectsRiskConcept'],
-         'inverse': 'isDetectedBy'} })
-    tag: Optional[str] = Field(default=None, description="""A shost version of the name""", json_schema_extra = { "linkml_meta": {'alias': 'tag', 'domain_of': ['Risk']} })
-    type: Optional[str] = Field(default=None, description="""Annotation whether an AI risk occurs at input or output or is non-technical.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['Risk']} })
-    phase: Optional[str] = Field(default=None, description="""Annotation whether an AI risk shows specifically during the training-tuning or inference phase.""", json_schema_extra = { "linkml_meta": {'alias': 'phase', 'domain_of': ['Risk']} })
-    descriptor: Optional[str] = Field(default=None, description="""Annotates whether an AI risk is a traditional risk, specific to or amplified by AI.""", json_schema_extra = { "linkml_meta": {'alias': 'descriptor', 'domain_of': ['Risk']} })
-    concern: Optional[str] = Field(default=None, description="""Some explanation about the concern related to an AI risk""", json_schema_extra = { "linkml_meta": {'alias': 'concern', 'domain_of': ['Risk']} })
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:Risk",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+            "mixins": ["RiskConcept"],
+            "slot_usage": {
+                "isPartOf": {
+                    "description": "A relationship where a risk is "
+                    "part of a risk group",
+                    "name": "isPartOf",
+                    "range": "RiskGroup",
+                }
+            },
+        }
+    )
+
+    hasRelatedAction: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where an entity relates to an action""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasRelatedAction", "domain_of": ["Risk"]}
+        },
+    )
+    isDefinedByTaxonomy: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk or a risk group is defined by a risk taxonomy""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDefinedByTaxonomy",
+                "domain_of": [
+                    "RiskGroup",
+                    "Risk",
+                    "RiskControl",
+                    "Action",
+                    "RiskIncident",
+                ],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    isPartOf: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk is part of a risk group""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isPartOf",
+                "domain_of": ["Risk", "LargeLanguageModel"],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    closeMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "closeMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:closeMatch",
+            }
+        },
+    )
+    exactMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "exactMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:exactMatch",
+            }
+        },
+    )
+    broadMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "broadMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:broadMatch",
+            }
+        },
+    )
+    narrowMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "narrowMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:narrowMatch",
+            }
+        },
+    )
+    relatedMatch: Optional[list[str]] = Field(
+        default=None,
+        description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "relatedMatch",
+                "any_of": [{"range": "Risk"}, {"range": "RiskGroup"}],
+                "domain_of": ["RiskGroup", "Risk"],
+                "slot_uri": "skos:relatedMatch",
+            }
+        },
+    )
+    detectsRiskConcept: Optional[list[str]] = Field(
+        default=None,
+        description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources, consequences, and impacts.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "detectsRiskConcept",
+                "domain": "RiskControl",
+                "domain_of": ["Risk", "RiskControl"],
+                "exact_mappings": ["airo:detectsRiskConcept"],
+                "inverse": "isDetectedBy",
+            }
+        },
+    )
+    tag: Optional[str] = Field(
+        default=None,
+        description="""A shost version of the name""",
+        json_schema_extra={"linkml_meta": {"alias": "tag", "domain_of": ["Risk"]}},
+    )
+    type: Optional[str] = Field(
+        default=None,
+        description="""Annotation whether an AI risk occurs at input or output or is non-technical.""",
+        json_schema_extra={"linkml_meta": {"alias": "type", "domain_of": ["Risk"]}},
+    )
+    phase: Optional[str] = Field(
+        default=None,
+        description="""Annotation whether an AI risk shows specifically during the training-tuning or inference phase.""",
+        json_schema_extra={"linkml_meta": {"alias": "phase", "domain_of": ["Risk"]}},
+    )
+    descriptor: Optional[str] = Field(
+        default=None,
+        description="""Annotates whether an AI risk is a traditional risk, specific to or amplified by AI.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "descriptor", "domain_of": ["Risk"]}
+        },
+    )
+    concern: Optional[str] = Field(
+        default=None,
+        description="""Some explanation about the concern related to an AI risk""",
+        json_schema_extra={"linkml_meta": {"alias": "concern", "domain_of": ["Risk"]}},
+    )
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class RiskControl(RiskConcept, Entity):
     """
     A measure that maintains and/or modifies risk (and risk concepts)
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:RiskControl',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
-         'mixins': ['RiskConcept']})
 
-    detectsRiskConcept: Optional[list[str]] = Field(default=None, description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources, consequences, and impacts.""", json_schema_extra = { "linkml_meta": {'alias': 'detectsRiskConcept',
-         'domain': 'RiskControl',
-         'domain_of': ['Risk', 'RiskControl'],
-         'exact_mappings': ['airo:detectsRiskConcept'],
-         'inverse': 'isDetectedBy'} })
-    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
-         'slot_uri': 'schema:isPartOf'} })
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:RiskControl",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+            "mixins": ["RiskConcept"],
+        }
+    )
+
+    detectsRiskConcept: Optional[list[str]] = Field(
+        default=None,
+        description="""The property airo:detectsRiskConcept indicates the control used for detecting risks, risk sources, consequences, and impacts.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "detectsRiskConcept",
+                "domain": "RiskControl",
+                "domain_of": ["Risk", "RiskControl"],
+                "exact_mappings": ["airo:detectsRiskConcept"],
+                "inverse": "isDetectedBy",
+            }
+        },
+    )
+    isDefinedByTaxonomy: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk or a risk group is defined by a risk taxonomy""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDefinedByTaxonomy",
+                "domain_of": [
+                    "RiskGroup",
+                    "Risk",
+                    "RiskControl",
+                    "Action",
+                    "RiskIncident",
+                ],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Action(Entity):
     """
     Action to remediate a risk
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
 
-    hasRelatedRisk: Optional[list[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk',
-         'domain': 'RiskConcept',
-         'domain_of': ['Action', 'AiEval']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
-         'slot_uri': 'schema:isPartOf'} })
-    hasAiActorTask: Optional[list[str]] = Field(default=None, description="""Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed will apply to every suggested action in the subcategory (i.e., some apply to AI development and others apply to AI deployment).""", json_schema_extra = { "linkml_meta": {'alias': 'hasAiActorTask', 'domain_of': ['Action']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk"}
+    )
+
+    hasRelatedRisk: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where an entity relates to a risk""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRelatedRisk",
+                "domain": "RiskConcept",
+                "domain_of": ["Action", "AiEval"],
+            }
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    isDefinedByTaxonomy: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk or a risk group is defined by a risk taxonomy""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDefinedByTaxonomy",
+                "domain_of": [
+                    "RiskGroup",
+                    "Risk",
+                    "RiskControl",
+                    "Action",
+                    "RiskIncident",
+                ],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    hasAiActorTask: Optional[list[str]] = Field(
+        default=None,
+        description="""Pertinent AI Actor Tasks for each subcategory. Not every AI Actor Task listed will apply to every suggested action in the subcategory (i.e., some apply to AI development and others apply to AI deployment).""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasAiActorTask", "domain_of": ["Action"]}
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class RiskIncident(RiskConcept, Entity):
     """
     An event occuring or occured which is a realised or materialised risk.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'https://w3id.org/dpv/risk#Incident',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
-         'mixins': ['RiskConcept']})
 
-    refersToRisk: Optional[list[str]] = Field(default=None, description="""Indicates the incident (subject) is a materialisation of the indicated risk (object)""", json_schema_extra = { "linkml_meta": {'alias': 'refersToRisk',
-         'domain': 'RiskIncident',
-         'domain_of': ['RiskIncident'],
-         'exact_mappings': ['dpv:refersToRisk']} })
-    isDefinedByTaxonomy: Optional[str] = Field(default=None, description="""A relationship where a risk or a risk group is defined by a risk taxonomy""", json_schema_extra = { "linkml_meta": {'alias': 'isDefinedByTaxonomy',
-         'domain_of': ['RiskGroup', 'Risk', 'RiskControl', 'Action', 'RiskIncident'],
-         'slot_uri': 'schema:isPartOf'} })
-    hasStatus: Optional[str] = Field(default=None, description="""Indicates the status of specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasStatus', 'domain': 'RiskConcept', 'domain_of': ['RiskIncident']} })
-    hasSeverity: Optional[str] = Field(default=None, description="""Indicates the severity associated with a concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasSeverity', 'domain': 'RiskConcept', 'domain_of': ['RiskIncident']} })
-    hasLikelihood: Optional[str] = Field(default=None, description="""The likelihood or probability or chance of something taking place or occuring""", json_schema_extra = { "linkml_meta": {'alias': 'hasLikelihood',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskIncident']} })
-    hasImpactOn: Optional[str] = Field(default=None, description="""Indicates impact(s) possible or arising as consequences from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasImpactOn',
-         'broad_mappings': ['dpv:hasConsequenceOn'],
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskIncident']} })
-    hasConsequence: Optional[str] = Field(default=None, description="""Indicates consequence(s) possible or arising from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasConsequence',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskIncident']} })
-    hasImpact: Optional[str] = Field(default=None, description="""Indicates impact(s) possible or arising as consequences from specified concept""", json_schema_extra = { "linkml_meta": {'alias': 'hasImpact',
-         'broad_mappings': ['dpv:hasConsequence'],
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskIncident']} })
-    hasVariant: Optional[str] = Field(default=None, description="""Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident.""", json_schema_extra = { "linkml_meta": {'alias': 'hasVariant', 'domain': 'RiskIncident', 'domain_of': ['RiskIncident']} })
-    author: Optional[str] = Field(default=None, description="""The author or authors of the incident report""", json_schema_extra = { "linkml_meta": {'alias': 'author', 'domain_of': ['RiskIncident']} })
-    source_uri: Optional[str] = Field(default=None, description="""The uri of the incident""", json_schema_extra = { "linkml_meta": {'alias': 'source_uri', 'domain_of': ['RiskIncident']} })
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "https://w3id.org/dpv/risk#Incident",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+            "mixins": ["RiskConcept"],
+        }
+    )
+
+    refersToRisk: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates the incident (subject) is a materialisation of the indicated risk (object)""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "refersToRisk",
+                "domain": "RiskIncident",
+                "domain_of": ["RiskIncident"],
+                "exact_mappings": ["dpv:refersToRisk"],
+            }
+        },
+    )
+    isDefinedByTaxonomy: Optional[str] = Field(
+        default=None,
+        description="""A relationship where a risk or a risk group is defined by a risk taxonomy""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDefinedByTaxonomy",
+                "domain_of": [
+                    "RiskGroup",
+                    "Risk",
+                    "RiskControl",
+                    "Action",
+                    "RiskIncident",
+                ],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    hasStatus: Optional[str] = Field(
+        default=None,
+        description="""Indicates the status of specified concept""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasStatus",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasSeverity: Optional[str] = Field(
+        default=None,
+        description="""Indicates the severity associated with a concept""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasSeverity",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasLikelihood: Optional[str] = Field(
+        default=None,
+        description="""The likelihood or probability or chance of something taking place or occuring""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLikelihood",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasImpactOn: Optional[str] = Field(
+        default=None,
+        description="""Indicates impact(s) possible or arising as consequences from specified concept""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasImpactOn",
+                "broad_mappings": ["dpv:hasConsequenceOn"],
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasConsequence: Optional[str] = Field(
+        default=None,
+        description="""Indicates consequence(s) possible or arising from specified concept""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasConsequence",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasImpact: Optional[str] = Field(
+        default=None,
+        description="""Indicates impact(s) possible or arising as consequences from specified concept""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasImpact",
+                "broad_mappings": ["dpv:hasConsequence"],
+                "domain": "RiskConcept",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    hasVariant: Optional[str] = Field(
+        default=None,
+        description="""Indicates an incident that shares the same causative factors, produces similar harms, and involves the same intelligent systems as a known AI incident.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasVariant",
+                "domain": "RiskIncident",
+                "domain_of": ["RiskIncident"],
+            }
+        },
+    )
+    author: Optional[str] = Field(
+        default=None,
+        description="""The author or authors of the incident report""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "author", "domain_of": ["RiskIncident"]}
+        },
+    )
+    source_uri: Optional[str] = Field(
+        default=None,
+        description="""The uri of the incident""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "source_uri", "domain_of": ["RiskIncident"]}
+        },
+    )
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Impact(RiskConcept, Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Impact',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk',
-         'mixins': ['RiskConcept']})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:Impact",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+            "mixins": ["RiskConcept"],
+        }
+    )
 
-    isDetectedBy: Optional[list[str]] = Field(default=None, description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""", json_schema_extra = { "linkml_meta": {'alias': 'isDetectedBy',
-         'domain': 'RiskConcept',
-         'domain_of': ['RiskConcept'],
-         'inverse': 'detectsRiskConcept'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    isDetectedBy: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a risk, risk source, consequence, or impact is detected by a risk control.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isDetectedBy",
+                "domain": "RiskConcept",
+                "domain_of": ["RiskConcept"],
+                "inverse": "detectsRiskConcept",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentStatus(Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentStatus',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentStatus",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentConcludedclass(IncidentStatus):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentConcludedclass',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentConcludedclass",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentHaltedclass(IncidentStatus):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentHaltedclass',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentHaltedclass",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentMitigatedclass(IncidentStatus):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentMitigatedclass',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentMitigatedclass",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentNearMissclass(IncidentStatus):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentNearMissclass',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentNearMissclass",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class IncidentOngoingclass(IncidentStatus):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:IncidentOngoingclass',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:IncidentOngoingclass",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Severity(Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Severity',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:Severity",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Likelihood(Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Likelihood',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:Likelihood",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Consequence(Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dpv:Consequence',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dpv:Consequence",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_risk",
+        }
+    )
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiEval(Entity):
     """
     An AI Evaluation, e.g. a metric, benchmark, unitxt card evaluation, a question or a combination of such entities.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dqv:Metric',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
-         'slot_usage': {'isComposedOf': {'description': 'A relationship indicating '
-                                                        'that an AI evaluation maybe '
-                                                        'composed of other AI '
-                                                        "evaluations (e.g. it's an "
-                                                        'overall average of other '
-                                                        'scores).',
-                                         'name': 'isComposedOf',
-                                         'range': 'AiEval'}}})
 
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[list[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasTasks: Optional[list[str]] = Field(default=None, description="""The tasks or evaluations the benchmark is intended to assess.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTasks', 'domain_of': ['AiEval', 'BenchmarkMetadataCard']} })
-    hasImplementation: Optional[list[str]] = Field(default=None, description="""A relationship to a implementation defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasImplementation',
-         'domain_of': ['AiEval'],
-         'slot_uri': 'schema:url'} })
-    hasUnitxtCard: Optional[list[str]] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[list[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk',
-         'domain': 'RiskConcept',
-         'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    hasBenchmarkMetadata: Optional[list[str]] = Field(default=None, description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'hasBenchmarkMetadata',
-         'domain': 'AiEval',
-         'domain_of': ['AiEval'],
-         'inverse': 'describesAiEval'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dqv:Metric",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval",
+            "slot_usage": {
+                "isComposedOf": {
+                    "description": "A relationship indicating "
+                    "that an AI evaluation maybe "
+                    "composed of other AI "
+                    "evaluations (e.g. it's an "
+                    "overall average of other "
+                    "scores).",
+                    "name": "isComposedOf",
+                    "range": "AiEval",
+                }
+            },
+        }
+    )
+
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasDataset: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to datasets that are used.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasDataset", "domain_of": ["AiEval"]}
+        },
+    )
+    hasTasks: Optional[list[str]] = Field(
+        default=None,
+        description="""The tasks or evaluations the benchmark is intended to assess.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasTasks",
+                "domain_of": ["AiEval", "BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasImplementation: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a implementation defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasImplementation",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasUnitxtCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Unitxt card defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasUnitxtCard",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    hasRelatedRisk: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where an entity relates to a risk""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRelatedRisk",
+                "domain": "RiskConcept",
+                "domain_of": ["Action", "AiEval"],
+            }
+        },
+    )
+    bestValue: Optional[str] = Field(
+        default=None,
+        description="""Annotation of the best possible result of the evaluation""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "bestValue", "domain_of": ["AiEval"]}
+        },
+    )
+    hasBenchmarkMetadata: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasBenchmarkMetadata",
+                "domain": "AiEval",
+                "domain_of": ["AiEval"],
+                "inverse": "describesAiEval",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiEvalResult(Fact, Entity):
     """
     The result of an evaluation for a specific AI model.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'dqv:QualityMeasurement',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
-         'mixins': ['Fact']})
 
-    isResultOf: Optional[str] = Field(default=None, description="""A relationship indicating that an entity is the result of an AI evaluation.""", json_schema_extra = { "linkml_meta": {'alias': 'isResultOf',
-         'domain_of': ['AiEvalResult'],
-         'slot_uri': 'dqv:isMeasurementOf'} })
-    value: str = Field(default=..., description="""Some numeric or string value""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['Fact']} })
-    evidence: Optional[str] = Field(default=None, description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""", json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Fact']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "dqv:QualityMeasurement",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval",
+            "mixins": ["Fact"],
+        }
+    )
+
+    isResultOf: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating that an entity is the result of an AI evaluation.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isResultOf",
+                "domain_of": ["AiEvalResult"],
+                "slot_uri": "dqv:isMeasurementOf",
+            }
+        },
+    )
+    value: str = Field(
+        default=...,
+        description="""Some numeric or string value""",
+        json_schema_extra={"linkml_meta": {"alias": "value", "domain_of": ["Fact"]}},
+    )
+    evidence: Optional[str] = Field(
+        default=None,
+        description="""Evidence provides a source (typical a chunk, paragraph or link) describing where some value was found or how it was generated.""",
+        json_schema_extra={"linkml_meta": {"alias": "evidence", "domain_of": ["Fact"]}},
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class BenchmarkMetadataCard(Entity):
     """
     Benchmark metadata cards offer a standardized way to document LLM benchmarks clearly and transparently. Inspired by Model Cards and Datasheets, Benchmark metadata cards help researchers and practitioners understand exactly what benchmarks test, how they relate to real-world risks, and how to interpret their results responsibly.  This is an implementation of the design set out in 'BenchmarkCards: Large Language Model and Risk Reporting' (https://doi.org/10.48550/arXiv.2410.12974)
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nexus:benchmarkmetadatacard',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval'})
 
-    describesAiEval: Optional[list[str]] = Field(default=None, description="""A relationship where a BenchmarkMetadataCard describes and AI evaluation (benchmark).""", json_schema_extra = { "linkml_meta": {'alias': 'describesAiEval',
-         'domain': 'BenchmarkMetadataCard',
-         'domain_of': ['BenchmarkMetadataCard'],
-         'inverse': 'hasBenchmarkMetadata'} })
-    hasDataType: Optional[list[str]] = Field(default=None, description="""The type of data used in the benchmark (e.g., text, images, or multi-modal)""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataType', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasDomains: Optional[list[str]] = Field(default=None, description="""The specific domains or areas where the benchmark is applied (e.g., natural language processing,computer vision).""", json_schema_extra = { "linkml_meta": {'alias': 'hasDomains', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasLanguages: Optional[list[str]] = Field(default=None, description="""The languages included in the dataset used by the benchmark (e.g., English, multilingual).""", json_schema_extra = { "linkml_meta": {'alias': 'hasLanguages', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasSimilarBenchmarks: Optional[list[str]] = Field(default=None, description="""Benchmarks that are closely related in terms of goals or data type.""", json_schema_extra = { "linkml_meta": {'alias': 'hasSimilarBenchmarks', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasResources: Optional[list[str]] = Field(default=None, description="""Links to relevant resources, such as repositories or papers related to the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'hasResources', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasGoal: Optional[str] = Field(default=None, description="""The specific goal or primary use case the benchmark is designed for.""", json_schema_extra = { "linkml_meta": {'alias': 'hasGoal', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasAudience: Optional[str] = Field(default=None, description="""The intended audience, such as researchers, developers, policymakers, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'hasAudience', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasTasks: Optional[list[str]] = Field(default=None, description="""The tasks or evaluations the benchmark is intended to assess.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTasks', 'domain_of': ['AiEval', 'BenchmarkMetadataCard']} })
-    hasLimitations: Optional[list[str]] = Field(default=None, description="""Limitations in evaluating or addressing risks, such as gaps in demographic coverage or specific domains.""", json_schema_extra = { "linkml_meta": {'alias': 'hasLimitations', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasOutOfScopeUses: Optional[list[str]] = Field(default=None, description="""Use cases where the benchmark is not designed to be applied and could give misleading results.""", json_schema_extra = { "linkml_meta": {'alias': 'hasOutOfScopeUses', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasDataSource: Optional[list[str]] = Field(default=None, description="""The origin or source of the data used in the benchmark (e.g., curated datasets, user submissions).""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataSource', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasDataSize: Optional[str] = Field(default=None, description="""The size of the dataset, including the number of data points or examples.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataSize', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasDataFormat: Optional[str] = Field(default=None, description="""The structure and modality of the data (e.g., sentence pairs, question-answer format, tabular data).""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataFormat', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasAnnotation: Optional[str] = Field(default=None, description="""The process used to annotate or label the dataset, including who or what performed the annotations (e.g., human annotators, automated processes).""", json_schema_extra = { "linkml_meta": {'alias': 'hasAnnotation', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasMethods: Optional[list[str]] = Field(default=None, description="""The evaluation techniques applied within the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'hasMethods', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasMetrics: Optional[list[str]] = Field(default=None, description="""The specific performance metrics used to assess models (e.g., accuracy, F1 score, precision, recall).""", json_schema_extra = { "linkml_meta": {'alias': 'hasMetrics', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasCalculation: Optional[list[str]] = Field(default=None, description="""The way metrics are computed based on model outputs and the benchmark data.""", json_schema_extra = { "linkml_meta": {'alias': 'hasCalculation', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasInterpretation: Optional[list[str]] = Field(default=None, description="""How users should interpret the scores or results from the metrics.""", json_schema_extra = { "linkml_meta": {'alias': 'hasInterpretation', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasBaselineResults: Optional[str] = Field(default=None, description="""The results of well-known or widely used models to give context to new performance scores.""", json_schema_extra = { "linkml_meta": {'alias': 'hasBaselineResults', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasValidation: Optional[list[str]] = Field(default=None, description="""Measures taken to ensure that the benchmark provides valid and reliable evaluations.""", json_schema_extra = { "linkml_meta": {'alias': 'hasValidation', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasRelatedRisks: Optional[list[str]] = Field(default=None, description="""Specific risks of LLMs the benchmark assesses""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisks', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasDemographicAnalysis: Optional[str] = Field(default=None, description="""How the benchmark evaluates performance across different demographic groups (e.g., gender, race).""", json_schema_extra = { "linkml_meta": {'alias': 'hasDemographicAnalysis', 'domain_of': ['BenchmarkMetadataCard']} })
-    hasConsiderationPrivacyAndAnonymity: Optional[str] = Field(default=None, description="""How any personal or sensitive data is handled and whether any anonymization techniques are applied.""", json_schema_extra = { "linkml_meta": {'alias': 'hasConsiderationPrivacyAndAnonymity',
-         'domain_of': ['BenchmarkMetadataCard']} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    hasConsiderationConsentProcedures: Optional[str] = Field(default=None, description="""Information on how consent was obtained (if applicable), especially for datasets involving personal data.""", json_schema_extra = { "linkml_meta": {'alias': 'hasConsiderationConsentProcedures',
-         'domain_of': ['BenchmarkMetadataCard']} })
-    hasConsiderationComplianceWithRegulations: Optional[str] = Field(default=None, description="""Compliance with relevant legal or ethical regulations (if applicable).""", json_schema_extra = { "linkml_meta": {'alias': 'hasConsiderationComplianceWithRegulations',
-         'domain_of': ['BenchmarkMetadataCard']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    name: Optional[str] = Field(default=None, description="""The official name of the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Entity', 'BenchmarkMetadataCard']} })
-    overview: Optional[str] = Field(default=None, description="""A brief description of the benchmark's main goals and scope.""", json_schema_extra = { "linkml_meta": {'alias': 'overview', 'domain_of': ['BenchmarkMetadataCard']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "nexus:benchmarkmetadatacard",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval",
+        }
+    )
+
+    describesAiEval: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where a BenchmarkMetadataCard describes and AI evaluation (benchmark).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "describesAiEval",
+                "domain": "BenchmarkMetadataCard",
+                "domain_of": ["BenchmarkMetadataCard"],
+                "inverse": "hasBenchmarkMetadata",
+            }
+        },
+    )
+    hasDataType: Optional[list[str]] = Field(
+        default=None,
+        description="""The type of data used in the benchmark (e.g., text, images, or multi-modal)""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDataType",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDomains: Optional[list[str]] = Field(
+        default=None,
+        description="""The specific domains or areas where the benchmark is applied (e.g., natural language processing,computer vision).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDomains",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasLanguages: Optional[list[str]] = Field(
+        default=None,
+        description="""The languages included in the dataset used by the benchmark (e.g., English, multilingual).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLanguages",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasSimilarBenchmarks: Optional[list[str]] = Field(
+        default=None,
+        description="""Benchmarks that are closely related in terms of goals or data type.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasSimilarBenchmarks",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasResources: Optional[list[str]] = Field(
+        default=None,
+        description="""Links to relevant resources, such as repositories or papers related to the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasResources",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasGoal: Optional[str] = Field(
+        default=None,
+        description="""The specific goal or primary use case the benchmark is designed for.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasGoal", "domain_of": ["BenchmarkMetadataCard"]}
+        },
+    )
+    hasAudience: Optional[str] = Field(
+        default=None,
+        description="""The intended audience, such as researchers, developers, policymakers, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasAudience",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasTasks: Optional[list[str]] = Field(
+        default=None,
+        description="""The tasks or evaluations the benchmark is intended to assess.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasTasks",
+                "domain_of": ["AiEval", "BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasLimitations: Optional[list[str]] = Field(
+        default=None,
+        description="""Limitations in evaluating or addressing risks, such as gaps in demographic coverage or specific domains.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLimitations",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasOutOfScopeUses: Optional[list[str]] = Field(
+        default=None,
+        description="""Use cases where the benchmark is not designed to be applied and could give misleading results.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasOutOfScopeUses",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDataSource: Optional[list[str]] = Field(
+        default=None,
+        description="""The origin or source of the data used in the benchmark (e.g., curated datasets, user submissions).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDataSource",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDataSize: Optional[str] = Field(
+        default=None,
+        description="""The size of the dataset, including the number of data points or examples.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDataSize",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDataFormat: Optional[str] = Field(
+        default=None,
+        description="""The structure and modality of the data (e.g., sentence pairs, question-answer format, tabular data).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDataFormat",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasAnnotation: Optional[str] = Field(
+        default=None,
+        description="""The process used to annotate or label the dataset, including who or what performed the annotations (e.g., human annotators, automated processes).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasAnnotation",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasMethods: Optional[list[str]] = Field(
+        default=None,
+        description="""The evaluation techniques applied within the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasMethods",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasMetrics: Optional[list[str]] = Field(
+        default=None,
+        description="""The specific performance metrics used to assess models (e.g., accuracy, F1 score, precision, recall).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasMetrics",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasCalculation: Optional[list[str]] = Field(
+        default=None,
+        description="""The way metrics are computed based on model outputs and the benchmark data.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasCalculation",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasInterpretation: Optional[list[str]] = Field(
+        default=None,
+        description="""How users should interpret the scores or results from the metrics.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasInterpretation",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasBaselineResults: Optional[str] = Field(
+        default=None,
+        description="""The results of well-known or widely used models to give context to new performance scores.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasBaselineResults",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasValidation: Optional[list[str]] = Field(
+        default=None,
+        description="""Measures taken to ensure that the benchmark provides valid and reliable evaluations.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasValidation",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasRelatedRisks: Optional[list[str]] = Field(
+        default=None,
+        description="""Specific risks of LLMs the benchmark assesses""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRelatedRisks",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDemographicAnalysis: Optional[str] = Field(
+        default=None,
+        description="""How the benchmark evaluates performance across different demographic groups (e.g., gender, race).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDemographicAnalysis",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasConsiderationPrivacyAndAnonymity: Optional[str] = Field(
+        default=None,
+        description="""How any personal or sensitive data is handled and whether any anonymization techniques are applied.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasConsiderationPrivacyAndAnonymity",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    hasConsiderationConsentProcedures: Optional[str] = Field(
+        default=None,
+        description="""Information on how consent was obtained (if applicable), especially for datasets involving personal data.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasConsiderationConsentProcedures",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasConsiderationComplianceWithRegulations: Optional[str] = Field(
+        default=None,
+        description="""Compliance with relevant legal or ethical regulations (if applicable).""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasConsiderationComplianceWithRegulations",
+                "domain_of": ["BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""The official name of the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+            }
+        },
+    )
+    overview: Optional[str] = Field(
+        default=None,
+        description="""A brief description of the benchmark's main goals and scope.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "overview", "domain_of": ["BenchmarkMetadataCard"]}
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Question(AiEval):
     """
     An evaluation where a question has to be answered
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval'})
 
-    text: str = Field(default=..., description="""The question itself""", json_schema_extra = { "linkml_meta": {'alias': 'text', 'domain_of': ['Question']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[list[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasTasks: Optional[list[str]] = Field(default=None, description="""The tasks or evaluations the benchmark is intended to assess.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTasks', 'domain_of': ['AiEval', 'BenchmarkMetadataCard']} })
-    hasImplementation: Optional[list[str]] = Field(default=None, description="""A relationship to a implementation defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasImplementation',
-         'domain_of': ['AiEval'],
-         'slot_uri': 'schema:url'} })
-    hasUnitxtCard: Optional[list[str]] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[list[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk',
-         'domain': 'RiskConcept',
-         'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    hasBenchmarkMetadata: Optional[list[str]] = Field(default=None, description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'hasBenchmarkMetadata',
-         'domain': 'AiEval',
-         'domain_of': ['AiEval'],
-         'inverse': 'describesAiEval'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval"}
+    )
+
+    text: str = Field(
+        default=...,
+        description="""The question itself""",
+        json_schema_extra={"linkml_meta": {"alias": "text", "domain_of": ["Question"]}},
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasDataset: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to datasets that are used.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasDataset", "domain_of": ["AiEval"]}
+        },
+    )
+    hasTasks: Optional[list[str]] = Field(
+        default=None,
+        description="""The tasks or evaluations the benchmark is intended to assess.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasTasks",
+                "domain_of": ["AiEval", "BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasImplementation: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a implementation defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasImplementation",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasUnitxtCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Unitxt card defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasUnitxtCard",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    hasRelatedRisk: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where an entity relates to a risk""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRelatedRisk",
+                "domain": "RiskConcept",
+                "domain_of": ["Action", "AiEval"],
+            }
+        },
+    )
+    bestValue: Optional[str] = Field(
+        default=None,
+        description="""Annotation of the best possible result of the evaluation""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "bestValue", "domain_of": ["AiEval"]}
+        },
+    )
+    hasBenchmarkMetadata: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasBenchmarkMetadata",
+                "domain": "AiEval",
+                "domain_of": ["AiEval"],
+                "inverse": "describesAiEval",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Questionnaire(AiEval):
     """
     A questionnaire groups questions
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval',
-         'slot_usage': {'composed_of': {'name': 'composed_of', 'range': 'Question'}}})
 
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasDataset: Optional[list[str]] = Field(default=None, description="""A relationship to datasets that are used.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDataset', 'domain_of': ['AiEval']} })
-    hasTasks: Optional[list[str]] = Field(default=None, description="""The tasks or evaluations the benchmark is intended to assess.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTasks', 'domain_of': ['AiEval', 'BenchmarkMetadataCard']} })
-    hasImplementation: Optional[list[str]] = Field(default=None, description="""A relationship to a implementation defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasImplementation',
-         'domain_of': ['AiEval'],
-         'slot_uri': 'schema:url'} })
-    hasUnitxtCard: Optional[list[str]] = Field(default=None, description="""A relationship to a Unitxt card defining the risk evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'hasUnitxtCard', 'domain_of': ['AiEval'], 'slot_uri': 'schema:url'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    hasRelatedRisk: Optional[list[str]] = Field(default=None, description="""A relationship where an entity relates to a risk""", json_schema_extra = { "linkml_meta": {'alias': 'hasRelatedRisk',
-         'domain': 'RiskConcept',
-         'domain_of': ['Action', 'AiEval']} })
-    bestValue: Optional[str] = Field(default=None, description="""Annotation of the best possible result of the evaluation""", json_schema_extra = { "linkml_meta": {'alias': 'bestValue', 'domain_of': ['AiEval']} })
-    hasBenchmarkMetadata: Optional[list[str]] = Field(default=None, description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""", json_schema_extra = { "linkml_meta": {'alias': 'hasBenchmarkMetadata',
-         'domain': 'AiEval',
-         'domain_of': ['AiEval'],
-         'inverse': 'describesAiEval'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_eval",
+            "slot_usage": {"composed_of": {"name": "composed_of", "range": "Question"}},
+        }
+    )
+
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasDataset: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to datasets that are used.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasDataset", "domain_of": ["AiEval"]}
+        },
+    )
+    hasTasks: Optional[list[str]] = Field(
+        default=None,
+        description="""The tasks or evaluations the benchmark is intended to assess.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasTasks",
+                "domain_of": ["AiEval", "BenchmarkMetadataCard"],
+            }
+        },
+    )
+    hasImplementation: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a implementation defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasImplementation",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasUnitxtCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Unitxt card defining the risk evaluation""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasUnitxtCard",
+                "domain_of": ["AiEval"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    hasRelatedRisk: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship where an entity relates to a risk""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRelatedRisk",
+                "domain": "RiskConcept",
+                "domain_of": ["Action", "AiEval"],
+            }
+        },
+    )
+    bestValue: Optional[str] = Field(
+        default=None,
+        description="""Annotation of the best possible result of the evaluation""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "bestValue", "domain_of": ["AiEval"]}
+        },
+    )
+    hasBenchmarkMetadata: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to a Benchmark Metadata Card which contains metadata about the benchmark.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasBenchmarkMetadata",
+                "domain": "AiEval",
+                "domain_of": ["AiEval"],
+                "inverse": "describesAiEval",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiOffice(Organization):
     """
     The EU AI Office (https://digital-strategy.ec.europa.eu/en/policies/ai-office)
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'schema:Organization',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/eu_ai_act'})
 
-    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "schema:Organization",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/eu_ai_act",
+        }
+    )
+
+    grants_license: Optional[str] = Field(
+        default=None,
+        description="""A relationship from a granting entity such as an Organization to a License instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "grants_license", "domain_of": ["Organization"]}
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class BaseAi(Entity):
     """
     Any type of AI, be it a LLM, RL agent, SVM, etc.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[list[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[list[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
-         'domain_of': ['BaseAi'],
-         'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "abstract": True,
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+        }
+    )
+
+    producer: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance which produces this instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "producer", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasModelCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to model card references.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasModelCard", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    performsTask: Optional[list[str]] = Field(
+        default=None,
+        description="""relationship indicating the AI tasks an AI model can perform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "performsTask", "domain_of": ["BaseAi"]}
+        },
+    )
+    isProvidedBy: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating the AI model has been provided by an AI model provider.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isProvidedBy",
+                "domain_of": ["BaseAi"],
+                "slot_uri": "airo:isProvidedBy",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiSystem(BaseAi):
     """
     A compound AI System composed of one or more AI capablities. ChatGPT is an example of an AI system which deploys multiple GPT AI models.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AISystem',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
-         'slot_usage': {'isComposedOf': {'description': 'Relationship indicating the '
-                                                        'AI components from which a '
-                                                        'complete AI system is '
-                                                        'composed.',
-                                         'name': 'isComposedOf',
-                                         'range': 'BaseAi'}}})
 
-    hasEuAiSystemType: Optional[AiSystemType] = Field(default=None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
-    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(default=None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
-    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[list[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[list[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
-         'domain_of': ['BaseAi'],
-         'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:AISystem",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+            "slot_usage": {
+                "isComposedOf": {
+                    "description": "Relationship indicating the "
+                    "AI components from which a "
+                    "complete AI system is "
+                    "composed.",
+                    "name": "isComposedOf",
+                    "range": "BaseAi",
+                }
+            },
+        }
+    )
+
+    hasEuAiSystemType: Optional[AiSystemType] = Field(
+        default=None,
+        description="""The type of system as defined by the EU AI Act.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasEuAiSystemType", "domain_of": ["AiSystem"]}
+        },
+    )
+    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(
+        default=None,
+        description="""The risk category of an AI system as defined by the EU AI Act.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasEuRiskCategory", "domain_of": ["AiSystem"]}
+        },
+    )
+    producer: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance which produces this instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "producer", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasModelCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to model card references.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasModelCard", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    performsTask: Optional[list[str]] = Field(
+        default=None,
+        description="""relationship indicating the AI tasks an AI model can perform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "performsTask", "domain_of": ["BaseAi"]}
+        },
+    )
+    isProvidedBy: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating the AI model has been provided by an AI model provider.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isProvidedBy",
+                "domain_of": ["BaseAi"],
+                "slot_uri": "airo:isProvidedBy",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiAgent(AiSystem):
     """
     An artificial intelligence (AI) agent refers to a system or program that is capable of autonomously performing tasks on behalf of a user or another system by designing its workflow and utilizing available tools.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
-         'slot_usage': {'isProvidedBy': {'description': 'A relationship indicating the '
-                                                        'AI agent has been provided by '
-                                                        'an AI systems provider.',
-                                         'name': 'isProvidedBy'}}})
 
-    hasEuAiSystemType: Optional[AiSystemType] = Field(default=None, description="""The type of system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuAiSystemType', 'domain_of': ['AiSystem']} })
-    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(default=None, description="""The risk category of an AI system as defined by the EU AI Act.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEuRiskCategory', 'domain_of': ['AiSystem']} })
-    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[list[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[list[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI agent has been provided by an AI systems provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
-         'domain_of': ['BaseAi'],
-         'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+            "slot_usage": {
+                "isProvidedBy": {
+                    "description": "A relationship indicating the "
+                    "AI agent has been provided by "
+                    "an AI systems provider.",
+                    "name": "isProvidedBy",
+                }
+            },
+        }
+    )
+
+    hasEuAiSystemType: Optional[AiSystemType] = Field(
+        default=None,
+        description="""The type of system as defined by the EU AI Act.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasEuAiSystemType", "domain_of": ["AiSystem"]}
+        },
+    )
+    hasEuRiskCategory: Optional[EuAiRiskCategory] = Field(
+        default=None,
+        description="""The risk category of an AI system as defined by the EU AI Act.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasEuRiskCategory", "domain_of": ["AiSystem"]}
+        },
+    )
+    producer: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance which produces this instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "producer", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasModelCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to model card references.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasModelCard", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    performsTask: Optional[list[str]] = Field(
+        default=None,
+        description="""relationship indicating the AI tasks an AI model can perform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "performsTask", "domain_of": ["BaseAi"]}
+        },
+    )
+    isProvidedBy: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating the AI agent has been provided by an AI systems provider.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isProvidedBy",
+                "domain_of": ["BaseAi"],
+                "slot_uri": "airo:isProvidedBy",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiModel(BaseAi):
     """
     A base AI Model class. No assumption about the type (SVM, LLM, etc.). Subclassed by model types (see LargeLanguageModel).
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    hasEvaluation: Optional[list[AiEvalResult]] = Field(default=None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
-         'domain_of': ['AiModel'],
-         'slot_uri': 'dqv:hasQualityMeasurement'} })
-    architecture: Optional[str] = Field(default=None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
-    gpu_hours: Optional[int] = Field(default=None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
-    power_consumption_w: Optional[int] = Field(default=None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
-    carbon_emitted: Optional[float] = Field(default=None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
-         'domain_of': ['AiModel'],
-         'unit': {'descriptive_name': 'tons of CO2 equivalent', 'symbol': 't CO2-eq'}} })
-    hasRiskControl: Optional[list[str]] = Field(default=None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
-         'domain_of': ['AiModel'],
-         'slot_uri': 'airo:hasRiskControl'} })
-    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[list[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[list[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
-         'domain_of': ['BaseAi'],
-         'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system"}
+    )
+
+    hasEvaluation: Optional[list[AiEvalResult]] = Field(
+        default=None,
+        description="""A relationship indicating that an entity has an AI evaluation result.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasEvaluation",
+                "domain_of": ["AiModel"],
+                "slot_uri": "dqv:hasQualityMeasurement",
+            }
+        },
+    )
+    architecture: Optional[str] = Field(
+        default=None,
+        description="""A description of the architecture of an AI such as 'Decoder-only'.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "architecture", "domain_of": ["AiModel"]}
+        },
+    )
+    gpu_hours: Optional[int] = Field(
+        default=None,
+        description="""GPU consumption in terms of hours""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {"alias": "gpu_hours", "domain_of": ["AiModel"]}
+        },
+    )
+    power_consumption_w: Optional[int] = Field(
+        default=None,
+        description="""power consumption in Watts""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {"alias": "power_consumption_w", "domain_of": ["AiModel"]}
+        },
+    )
+    carbon_emitted: Optional[float] = Field(
+        default=None,
+        description="""The number of tons of carbon dioxide equivalent that are emitted during training""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "carbon_emitted",
+                "domain_of": ["AiModel"],
+                "unit": {
+                    "descriptive_name": "tons of CO2 equivalent",
+                    "symbol": "t CO2-eq",
+                },
+            }
+        },
+    )
+    hasRiskControl: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates the control measures associated with a system or component to modify risks.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRiskControl",
+                "domain_of": ["AiModel"],
+                "slot_uri": "airo:hasRiskControl",
+            }
+        },
+    )
+    producer: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance which produces this instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "producer", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasModelCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to model card references.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasModelCard", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    performsTask: Optional[list[str]] = Field(
+        default=None,
+        description="""relationship indicating the AI tasks an AI model can perform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "performsTask", "domain_of": ["BaseAi"]}
+        },
+    )
+    isProvidedBy: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating the AI model has been provided by an AI model provider.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isProvidedBy",
+                "domain_of": ["BaseAi"],
+                "slot_uri": "airo:isProvidedBy",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class LargeLanguageModel(AiModel):
     """
     A large language model (LLM) is an AI model which supports a range of language-related tasks such as generation, summarization, classification, among others. A LLM is implemented as an artificial neural networks using a transformer architecture.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['LLM'],
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system',
-         'slot_usage': {'isPartOf': {'description': 'Annotation that a Large Language '
-                                                    'model is part of a family of '
-                                                    'models',
-                                     'name': 'isPartOf',
-                                     'range': 'LargeLanguageModelFamily'}}})
 
-    numParameters: Optional[int] = Field(default=None, description="""A property indicating the number of parameters in a LLM.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numParameters', 'domain_of': ['LargeLanguageModel']} })
-    numTrainingTokens: Optional[int] = Field(default=None, description="""The number of tokens a AI model was trained on.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'numTrainingTokens', 'domain_of': ['LargeLanguageModel']} })
-    contextWindowSize: Optional[int] = Field(default=None, description="""The total length, in bytes, of an AI model's context window.""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'contextWindowSize', 'domain_of': ['LargeLanguageModel']} })
-    hasInputModality: Optional[list[str]] = Field(default=None, description="""A relationship indicating the input modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasInputModality', 'domain_of': ['LargeLanguageModel']} })
-    hasOutputModality: Optional[list[str]] = Field(default=None, description="""A relationship indicating the output modalities supported by an AI component. Examples include text, image, video.""", json_schema_extra = { "linkml_meta": {'alias': 'hasOutputModality', 'domain_of': ['LargeLanguageModel']} })
-    hasTrainingData: Optional[list[str]] = Field(default=None, description="""A relationship indicating the datasets an AI model was trained on.""", json_schema_extra = { "linkml_meta": {'alias': 'hasTrainingData',
-         'domain_of': ['LargeLanguageModel'],
-         'slot_uri': 'airo:hasTrainingData'} })
-    fine_tuning: Optional[str] = Field(default=None, description="""A description of the fine-tuning mechanism(s) applied to a model.""", json_schema_extra = { "linkml_meta": {'alias': 'fine_tuning', 'domain_of': ['LargeLanguageModel']} })
-    supported_languages: Optional[list[str]] = Field(default=None, description="""A list of languages, expressed as ISO two letter codes. For example, 'jp, fr, en, de'""", json_schema_extra = { "linkml_meta": {'alias': 'supported_languages', 'domain_of': ['LargeLanguageModel']} })
-    isPartOf: Optional[str] = Field(default=None, description="""Annotation that a Large Language model is part of a family of models""", json_schema_extra = { "linkml_meta": {'alias': 'isPartOf',
-         'domain_of': ['Risk', 'LargeLanguageModel'],
-         'slot_uri': 'schema:isPartOf'} })
-    hasEvaluation: Optional[list[AiEvalResult]] = Field(default=None, description="""A relationship indicating that an entity has an AI evaluation result.""", json_schema_extra = { "linkml_meta": {'alias': 'hasEvaluation',
-         'domain_of': ['AiModel'],
-         'slot_uri': 'dqv:hasQualityMeasurement'} })
-    architecture: Optional[str] = Field(default=None, description="""A description of the architecture of an AI such as 'Decoder-only'.""", json_schema_extra = { "linkml_meta": {'alias': 'architecture', 'domain_of': ['AiModel']} })
-    gpu_hours: Optional[int] = Field(default=None, description="""GPU consumption in terms of hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'gpu_hours', 'domain_of': ['AiModel']} })
-    power_consumption_w: Optional[int] = Field(default=None, description="""power consumption in Watts""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'power_consumption_w', 'domain_of': ['AiModel']} })
-    carbon_emitted: Optional[float] = Field(default=None, description="""The number of tons of carbon dioxide equivalent that are emitted during training""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'carbon_emitted',
-         'domain_of': ['AiModel'],
-         'unit': {'descriptive_name': 'tons of CO2 equivalent', 'symbol': 't CO2-eq'}} })
-    hasRiskControl: Optional[list[str]] = Field(default=None, description="""Indicates the control measures associated with a system or component to modify risks.""", json_schema_extra = { "linkml_meta": {'alias': 'hasRiskControl',
-         'domain_of': ['AiModel'],
-         'slot_uri': 'airo:hasRiskControl'} })
-    producer: Optional[str] = Field(default=None, description="""A relationship to the Organization instance which produces this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'producer', 'domain_of': ['BaseAi']} })
-    hasModelCard: Optional[list[str]] = Field(default=None, description="""A relationship to model card references.""", json_schema_extra = { "linkml_meta": {'alias': 'hasModelCard', 'domain_of': ['BaseAi']} })
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'alias': 'hasLicense',
-         'domain_of': ['Dataset',
-                       'Documentation',
-                       'RiskTaxonomy',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi'],
-         'slot_uri': 'airo:hasLicense'} })
-    performsTask: Optional[list[str]] = Field(default=None, description="""relationship indicating the AI tasks an AI model can perform.""", json_schema_extra = { "linkml_meta": {'alias': 'performsTask', 'domain_of': ['BaseAi']} })
-    isProvidedBy: Optional[str] = Field(default=None, description="""A relationship indicating the AI model has been provided by an AI model provider.""", json_schema_extra = { "linkml_meta": {'alias': 'isProvidedBy',
-         'domain_of': ['BaseAi'],
-         'slot_uri': 'airo:isProvidedBy'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "aliases": ["LLM"],
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+            "slot_usage": {
+                "isPartOf": {
+                    "description": "Annotation that a Large Language "
+                    "model is part of a family of "
+                    "models",
+                    "name": "isPartOf",
+                    "range": "LargeLanguageModelFamily",
+                }
+            },
+        }
+    )
+
+    numParameters: Optional[int] = Field(
+        default=None,
+        description="""A property indicating the number of parameters in a LLM.""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "numParameters",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    numTrainingTokens: Optional[int] = Field(
+        default=None,
+        description="""The number of tokens a AI model was trained on.""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "numTrainingTokens",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    contextWindowSize: Optional[int] = Field(
+        default=None,
+        description="""The total length, in bytes, of an AI model's context window.""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "contextWindowSize",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    hasInputModality: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship indicating the input modalities supported by an AI component. Examples include text, image, video.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasInputModality",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    hasOutputModality: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship indicating the output modalities supported by an AI component. Examples include text, image, video.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasOutputModality",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    hasTrainingData: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship indicating the datasets an AI model was trained on.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasTrainingData",
+                "domain_of": ["LargeLanguageModel"],
+                "slot_uri": "airo:hasTrainingData",
+            }
+        },
+    )
+    fine_tuning: Optional[str] = Field(
+        default=None,
+        description="""A description of the fine-tuning mechanism(s) applied to a model.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "fine_tuning", "domain_of": ["LargeLanguageModel"]}
+        },
+    )
+    supported_languages: Optional[list[str]] = Field(
+        default=None,
+        description="""A list of languages, expressed as ISO two letter codes. For example, 'jp, fr, en, de'""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "supported_languages",
+                "domain_of": ["LargeLanguageModel"],
+            }
+        },
+    )
+    isPartOf: Optional[str] = Field(
+        default=None,
+        description="""Annotation that a Large Language model is part of a family of models""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isPartOf",
+                "domain_of": ["Risk", "LargeLanguageModel"],
+                "slot_uri": "schema:isPartOf",
+            }
+        },
+    )
+    hasEvaluation: Optional[list[AiEvalResult]] = Field(
+        default=None,
+        description="""A relationship indicating that an entity has an AI evaluation result.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasEvaluation",
+                "domain_of": ["AiModel"],
+                "slot_uri": "dqv:hasQualityMeasurement",
+            }
+        },
+    )
+    architecture: Optional[str] = Field(
+        default=None,
+        description="""A description of the architecture of an AI such as 'Decoder-only'.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "architecture", "domain_of": ["AiModel"]}
+        },
+    )
+    gpu_hours: Optional[int] = Field(
+        default=None,
+        description="""GPU consumption in terms of hours""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {"alias": "gpu_hours", "domain_of": ["AiModel"]}
+        },
+    )
+    power_consumption_w: Optional[int] = Field(
+        default=None,
+        description="""power consumption in Watts""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {"alias": "power_consumption_w", "domain_of": ["AiModel"]}
+        },
+    )
+    carbon_emitted: Optional[float] = Field(
+        default=None,
+        description="""The number of tons of carbon dioxide equivalent that are emitted during training""",
+        ge=0,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "carbon_emitted",
+                "domain_of": ["AiModel"],
+                "unit": {
+                    "descriptive_name": "tons of CO2 equivalent",
+                    "symbol": "t CO2-eq",
+                },
+            }
+        },
+    )
+    hasRiskControl: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates the control measures associated with a system or component to modify risks.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasRiskControl",
+                "domain_of": ["AiModel"],
+                "slot_uri": "airo:hasRiskControl",
+            }
+        },
+    )
+    producer: Optional[str] = Field(
+        default=None,
+        description="""A relationship to the Organization instance which produces this instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "producer", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasModelCard: Optional[list[str]] = Field(
+        default=None,
+        description="""A relationship to model card references.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "hasModelCard", "domain_of": ["BaseAi"]}
+        },
+    )
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    hasLicense: Optional[str] = Field(
+        default=None,
+        description="""Indicates licenses associated with a resource""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasLicense",
+                "domain_of": [
+                    "Dataset",
+                    "Documentation",
+                    "RiskTaxonomy",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                ],
+                "slot_uri": "airo:hasLicense",
+            }
+        },
+    )
+    performsTask: Optional[list[str]] = Field(
+        default=None,
+        description="""relationship indicating the AI tasks an AI model can perform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "performsTask", "domain_of": ["BaseAi"]}
+        },
+    )
+    isProvidedBy: Optional[str] = Field(
+        default=None,
+        description="""A relationship indicating the AI model has been provided by an AI model provider.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "isProvidedBy",
+                "domain_of": ["BaseAi"],
+                "slot_uri": "airo:isProvidedBy",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class LargeLanguageModelFamily(Entity):
     """
     A large language model family is a set of models that are provided by the same AI systems provider and are built around the same architecture, but differ e.g. in the number of parameters. Examples are Meta's Llama2 family or the IBM granite models.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    hasDocumentation: Optional[list[str]] = Field(default=None, description="""Indicates documentation associated with an entity.""", json_schema_extra = { "linkml_meta": {'alias': 'hasDocumentation',
-         'domain_of': ['Dataset',
-                       'RiskTaxonomy',
-                       'Action',
-                       'AiEval',
-                       'BenchmarkMetadataCard',
-                       'BaseAi',
-                       'LargeLanguageModelFamily'],
-         'slot_uri': 'airo:hasDocumentation'} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system"}
+    )
+
+    hasDocumentation: Optional[list[str]] = Field(
+        default=None,
+        description="""Indicates documentation associated with an entity.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "hasDocumentation",
+                "domain_of": [
+                    "Dataset",
+                    "RiskTaxonomy",
+                    "Action",
+                    "AiEval",
+                    "BenchmarkMetadataCard",
+                    "BaseAi",
+                    "LargeLanguageModelFamily",
+                ],
+                "slot_uri": "airo:hasDocumentation",
+            }
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiTask(Entity):
     """
     A task, such as summarization and classification, performed by an AI.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AiCapability',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:AiCapability",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+        }
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiLifecyclePhase(Entity):
     """
     A Phase of AI lifecycle which indicates evolution of the system from conception through retirement.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
-         'class_uri': 'airo:AILifecyclePhase',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "abstract": True,
+            "class_uri": "airo:AILifecyclePhase",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+        }
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class DataPreprocessing(AiLifecyclePhase):
     """
     Data transformations, such as PI filtering, performed to ensure high quality of AI model training data.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system"}
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiModelValidation(AiLifecyclePhase):
     """
     AI model validation steps that have been performed after the model training to ensure high AI model quality.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {"from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system"}
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class AiProvider(Organization):
     """
     A provider under the AI Act is defined by Article 3(3) as a natural or legal person or body that develops an AI system or general-purpose AI model or has an AI system or general-purpose AI model developed; and places that system or model on the market, or puts that system into service, under the provider's own name or trademark, whether for payment or free for charge.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:AIProvider',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    grants_license: Optional[str] = Field(default=None, description="""A relationship from a granting entity such as an Organization to a License instance.""", json_schema_extra = { "linkml_meta": {'alias': 'grants_license', 'domain_of': ['Organization']} })
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:AIProvider",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+        }
+    )
+
+    grants_license: Optional[str] = Field(
+        default=None,
+        description="""A relationship from a granting entity such as an Organization to a License instance.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "grants_license", "domain_of": ["Organization"]}
+        },
+    )
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Modality(Entity):
     """
     A modality supported by an Ai component. Examples include text, image, video.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Modality',
-         'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai_system'})
 
-    id: str = Field(default=..., description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Entity'], 'slot_uri': 'schema:identifier'} })
-    name: Optional[str] = Field(default=None, description="""A text name of this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Entity', 'BenchmarkMetadataCard'],
-         'slot_uri': 'schema:name'} })
-    description: Optional[str] = Field(default=None, description="""The description of an entity""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:description'} })
-    url: Optional[str] = Field(default=None, description="""An optional URL associated with this instance.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['Entity'], 'slot_uri': 'schema:url'} })
-    dateCreated: Optional[date] = Field(default=None, description="""The date on which the entity was created.""", json_schema_extra = { "linkml_meta": {'alias': 'dateCreated',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateCreated'} })
-    dateModified: Optional[date] = Field(default=None, description="""The date on which the entity was most recently modified.""", json_schema_extra = { "linkml_meta": {'alias': 'dateModified',
-         'domain_of': ['Entity'],
-         'slot_uri': 'schema:dateModified'} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "class_uri": "airo:Modality",
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai_system",
+        }
+    )
+
+    id: str = Field(
+        default=...,
+        description="""A unique identifier to this instance of the model element. Example identifiers include UUID, URI, URN, etc.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "id",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:identifier",
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""A text name of this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Entity", "BenchmarkMetadataCard"],
+                "slot_uri": "schema:name",
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""The description of an entity""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:description",
+            }
+        },
+    )
+    url: Optional[str] = Field(
+        default=None,
+        description="""An optional URL associated with this instance.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:url",
+            }
+        },
+    )
+    dateCreated: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was created.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateCreated",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateCreated",
+            }
+        },
+    )
+    dateModified: Optional[date] = Field(
+        default=None,
+        description="""The date on which the entity was most recently modified.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "dateModified",
+                "domain_of": ["Entity"],
+                "slot_uri": "schema:dateModified",
+            }
+        },
+    )
 
 
 class Container(ConfiguredBaseModel):
     """
     An umbrella object that holds the ontology class instances
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology',
-         'tree_root': True})
 
-    organizations: Optional[list[Organization]] = Field(default=None, description="""A list of organizations""", json_schema_extra = { "linkml_meta": {'alias': 'organizations', 'domain_of': ['Container']} })
-    licenses: Optional[list[License]] = Field(default=None, description="""A list of licenses""", json_schema_extra = { "linkml_meta": {'alias': 'licenses', 'domain_of': ['Container']} })
-    modalities: Optional[list[Modality]] = Field(default=None, description="""A list of AI modalities""", json_schema_extra = { "linkml_meta": {'alias': 'modalities', 'domain_of': ['Container']} })
-    aitasks: Optional[list[AiTask]] = Field(default=None, description="""A list of AI tasks""", json_schema_extra = { "linkml_meta": {'alias': 'aitasks', 'domain_of': ['Container']} })
-    documents: Optional[list[Documentation]] = Field(default=None, description="""A list of documents""", json_schema_extra = { "linkml_meta": {'alias': 'documents', 'domain_of': ['Container']} })
-    datasets: Optional[list[Dataset]] = Field(default=None, description="""A list of data sets""", json_schema_extra = { "linkml_meta": {'alias': 'datasets', 'domain_of': ['Container']} })
-    taxonomies: Optional[list[RiskTaxonomy]] = Field(default=None, description="""A list of AI risk taxonomies""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomies', 'domain_of': ['Container']} })
-    riskgroups: Optional[list[RiskGroup]] = Field(default=None, description="""A list of AI risk groups""", json_schema_extra = { "linkml_meta": {'alias': 'riskgroups', 'domain_of': ['Container']} })
-    risks: Optional[list[Risk]] = Field(default=None, description="""A list of AI risks""", json_schema_extra = { "linkml_meta": {'alias': 'risks', 'domain_of': ['Container']} })
-    riskcontrols: Optional[list[RiskControl]] = Field(default=None, description="""A list of AI risk controls""", json_schema_extra = { "linkml_meta": {'alias': 'riskcontrols', 'domain_of': ['Container']} })
-    riskincidents: Optional[list[RiskIncident]] = Field(default=None, description="""A list of AI risk incidents""", json_schema_extra = { "linkml_meta": {'alias': 'riskincidents', 'domain_of': ['Container']} })
-    actions: Optional[list[Action]] = Field(default=None, description="""A list of risk related actions""", json_schema_extra = { "linkml_meta": {'alias': 'actions', 'domain_of': ['Container']} })
-    evaluations: Optional[list[AiEval]] = Field(default=None, description="""A list of AI evaluation methods""", json_schema_extra = { "linkml_meta": {'alias': 'evaluations', 'domain_of': ['Container']} })
-    benchmarkmetadatacards: Optional[list[BenchmarkMetadataCard]] = Field(default=None, description="""A list of AI evaluation benchmark metadata cards""", json_schema_extra = { "linkml_meta": {'alias': 'benchmarkmetadatacards', 'domain_of': ['Container']} })
-    aimodelfamilies: Optional[list[LargeLanguageModelFamily]] = Field(default=None, description="""A list of AI model families""", json_schema_extra = { "linkml_meta": {'alias': 'aimodelfamilies', 'domain_of': ['Container']} })
-    aimodels: Optional[list[LargeLanguageModel]] = Field(default=None, description="""A list of AI models""", json_schema_extra = { "linkml_meta": {'alias': 'aimodels', 'domain_of': ['Container']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://ibm.github.io/risk-atlas-nexus/ontology/ai-risk-ontology",
+            "tree_root": True,
+        }
+    )
+
+    organizations: Optional[list[Organization]] = Field(
+        default=None,
+        description="""A list of organizations""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "organizations", "domain_of": ["Container"]}
+        },
+    )
+    licenses: Optional[list[License]] = Field(
+        default=None,
+        description="""A list of licenses""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "licenses", "domain_of": ["Container"]}
+        },
+    )
+    modalities: Optional[list[Modality]] = Field(
+        default=None,
+        description="""A list of AI modalities""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "modalities", "domain_of": ["Container"]}
+        },
+    )
+    aitasks: Optional[list[AiTask]] = Field(
+        default=None,
+        description="""A list of AI tasks""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "aitasks", "domain_of": ["Container"]}
+        },
+    )
+    documents: Optional[list[Documentation]] = Field(
+        default=None,
+        description="""A list of documents""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "documents", "domain_of": ["Container"]}
+        },
+    )
+    datasets: Optional[list[Dataset]] = Field(
+        default=None,
+        description="""A list of data sets""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "datasets", "domain_of": ["Container"]}
+        },
+    )
+    taxonomies: Optional[list[RiskTaxonomy]] = Field(
+        default=None,
+        description="""A list of AI risk taxonomies""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "taxonomies", "domain_of": ["Container"]}
+        },
+    )
+    riskgroups: Optional[list[RiskGroup]] = Field(
+        default=None,
+        description="""A list of AI risk groups""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "riskgroups", "domain_of": ["Container"]}
+        },
+    )
+    risks: Optional[list[Risk]] = Field(
+        default=None,
+        description="""A list of AI risks""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "risks", "domain_of": ["Container"]}
+        },
+    )
+    riskcontrols: Optional[list[RiskControl]] = Field(
+        default=None,
+        description="""A list of AI risk controls""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "riskcontrols", "domain_of": ["Container"]}
+        },
+    )
+    riskincidents: Optional[list[RiskIncident]] = Field(
+        default=None,
+        description="""A list of AI risk incidents""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "riskincidents", "domain_of": ["Container"]}
+        },
+    )
+    actions: Optional[list[Action]] = Field(
+        default=None,
+        description="""A list of risk related actions""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "actions", "domain_of": ["Container"]}
+        },
+    )
+    evaluations: Optional[list[AiEval]] = Field(
+        default=None,
+        description="""A list of AI evaluation methods""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "evaluations", "domain_of": ["Container"]}
+        },
+    )
+    benchmarkmetadatacards: Optional[list[BenchmarkMetadataCard]] = Field(
+        default=None,
+        description="""A list of AI evaluation benchmark metadata cards""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "benchmarkmetadatacards",
+                "domain_of": ["Container"],
+            }
+        },
+    )
+    aimodelfamilies: Optional[list[LargeLanguageModelFamily]] = Field(
+        default=None,
+        description="""A list of AI model families""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "aimodelfamilies", "domain_of": ["Container"]}
+        },
+    )
+    aimodels: Optional[list[LargeLanguageModel]] = Field(
+        default=None,
+        description="""A list of AI models""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "aimodels", "domain_of": ["Container"]}
+        },
+    )
 
 
 # Model rebuild

--- a/src/risk_atlas_nexus/data/knowledge_graph/risk_atlas_data_incidents.yaml
+++ b/src/risk_atlas_nexus/data/knowledge_graph/risk_atlas_data_incidents.yaml
@@ -1,0 +1,531 @@
+riskincidents:
+- id: ibm-ai-risk-atlas-ri-ai-based-biological-attacks
+  name: AI-based Biological Attacks
+  description: As per the source article, large language models could help in the
+    planning and execution of a biological attack. Several test scenarios are mentioned
+    such as using LLMs to identify biological agents and their relative chances of
+    harm to human life. The article also highlighted the open question which is the
+    level of threat LLMs present beyond the harmful information that is readily available
+    online.
+  refersToRisk:
+  - atlas-dangerous-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, October 2023
+  source_uri: https://www.theguardian.com/technology/2023/oct/16/ai-chatbots-could-help-plan-bioweapon-attacks-report-finds
+- id: ibm-ai-risk-atlas-ri-healthcare-bias
+  name: Healthcare Bias
+  description: According to the research article on reinforcing disparities in medicine
+    using data and AI applications to transform how people receive healthcare is only
+    as strong as the data behind the effort. For example, using training data with
+    poor minority representation or that reflects what is already unequal care can
+    lead to increased health inequalities.
+  refersToRisk:
+  - atlas-data-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, December 2022
+  source_uri: https://www.forbes.com/sites/adigaskell/2022/12/02/minority-patients-often-left-behind-by-health-ai/?sh=31d28a225b41
+- id: ibm-ai-risk-atlas-ri-undisclosed-ai-interaction
+  name: Undisclosed AI Interaction
+  description: According to the source article, an online emotional support chat service
+    ran a study to augment or write responses to around 4,000 users by using  GPT-3
+    without informing users. The co-founder faced immense public backlash about the
+    potential for harm that is caused by AI-generated chats to the already vulnerable
+    users. He claimed that the study was “exempt” from informed consent law.
+  refersToRisk:
+  - atlas-non-disclosure
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, Jan 2023
+  source_uri: https://www.businessinsider.com/company-using-chatgpt-mental-health-support-ethical-issues-2023-1
+- id: ibm-ai-risk-atlas-ri-ai-based-cyberattacks
+  name: AI-based Cyberattacks
+  description: According to the source article, hackers are increasingly experimenting
+    with ChatGPT and other AI tools, enabling a wider range of actors to carry out
+    cyberattacks and scams. Microsoft has warned that state-backed hackers have been
+    using OpenAI’s LLMs to improve their cyberattacks, refining scripts, and improve
+    their targeted techniques. The article also mentions about a case where Microsoft
+    and OpenAI say they detected attempts from attackers and sharp increase in cyberattacks
+    targeting government offices.
+  refersToRisk:
+  - atlas-dangerous-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, February 2024
+  source_uri: https://time.com/6717129/hackers-ai-2024-elections/
+- id: ibm-ai-risk-atlas-ri-generation-of-less-secure-code
+  name: Generation of Less Secure Code
+  description: According to their paper, researchers at Stanford University investigated
+    the impact of code-generation tools on code quality and found that programmers
+    tend to include <em>more</em> bugs in their final code when they use AI assistants.
+    These bugs might increase the code's security vulnerabilities, yet the programmers
+    believed their code to be <em>more</em> secure.
+  refersToRisk:
+  - atlas-harmful-code-generation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Neil Perry, Megha Srivastava, Deepak Kumar, and Dan Boneh. 2023. Do Users
+    Write More Insecure Code with AI Assistants?. In Proceedings of the 2023 ACM SIGSAC
+    Conference on Computer and Communications Security (CCS '23), November 26-30,
+    2023, Copenhagen, Denmark. ACM, New York, NY, USA, 15 pages.
+  source_uri: https://dl.acm.org/doi/10.1145/3576915.3623157
+- id: ibm-ai-risk-atlas-ri-replacing-human-workers
+  name: Replacing Human Workers
+  description: According to the news article, AI technology replicating individuals'
+    faces and voices is becoming more prominent in Hollywood. The actors’ concerns
+    highlight a broader anxiety among entertainers and people in many other creative
+    professions. Many fear that without strict regulation, their work gets replicated
+    and remixed by artificial intelligence tools. Transformation on that scale will
+    cut their control over their work and hurts their ability to earn a living. One
+    of their key concerns is AI replacing non-speaking background roles by instead
+    using a digital likeness.
+  refersToRisk:
+  - atlas-impact-on-jobs
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023
+  source_uri: https://www.reuters.com/technology/actors-decry-existential-crisis-over-ai-generated-synthetic-actors-2023-07-21/
+- id: ibm-ai-risk-atlas-ri-increased-carbon-emissions
+  name: Increased Carbon Emissions
+  description: According to the source article, training earlier chatbots models such
+    as GPT-3 led to the production of 500 metric tons of greenhouse gas emissions—equivalent
+    to about 1 million miles driven by a conventional gasoline-powered vehicle. This
+    same model required more than 1,200 MWh during the training phase—roughly the
+    amount of energy used in a million American homes in one hour.
+  refersToRisk:
+  - atlas-impact-on-the-environment
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Brookings, January 2024
+  source_uri: https://www.brookings.edu/articles/the-us-must-balance-climate-justice-challenges-in-the-era-of-artificial-intelligence/
+- id: ibm-ai-risk-atlas-ri-bypassing-llm-guardrails
+  name: Bypassing LLM guardrails
+  description: A study cited by researchers at Carnegie Mellon University, The Center
+    for AI Safety, and the Bosch Center for AI, claim to have discovered a simple
+    prompt addendum that allowed the researchers to trick models into generating biased,
+    false, and otherwise toxic information. The researchers showed that they might
+    circumvent these guardrails in a more automated way. These attacks were shown
+    to be effective in a wide range of open source products, including ChatGPT, Google
+    Bard, Meta’s LLaMA, Anthropic’s Claude, and others.
+  refersToRisk:
+  - atlas-jailbreaking
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The New York Times, July 2023
+  source_uri: https://www.nytimes.com/2023/07/27/business/ai-chatgpt-safety-research.html
+- id: ibm-ai-risk-atlas-ri-audio-deepfakes
+  name: Audio Deepfakes
+  description: According to the source article, the Federal Communications Commission
+    outlawed robocalls that contain voices that are generated by artificial intelligence.
+    The announcement came after AI-generated robocalls mimicked the President's voice
+    to discourage people from voting in the state's first-in-the-nation primary.
+  refersToRisk:
+  - atlas-nonconsensual-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, February 2024
+  source_uri: https://apnews.com/article/fcc-elections-artificial-intelligence-robocalls-regulations-a8292b1371b3764916461f60660b93e6
+- id: ibm-ai-risk-atlas-ri-adversarial-attacks-on-autonomous-vehicles
+  name: Adversarial attacks on autonomous vehicles
+  description: 'A report from the European Union Agency for Cybersecurity (ENISA)
+    found that autonomous vehicles are “highly vulnerable to a wide range of attacks”
+    that could be dangerous for passengers, pedestrians, and people in other vehicles.
+    The report states that an adversarial attack might be used to make the AI ''blind''
+    to pedestrians by manipulating the image recognition component to misclassify
+    pedestrians. This attack could lead to havoc on the streets, as autonomous cars
+    might hit pedestrians on the roads or crosswalks.Other studies demonstrated potential
+    adversarial attacks on autonomous vehicles: <ul><li>Fooling machine learning algorithms
+    by making minor changes to street sign graphics, such as adding stickers. </li><li>Security
+    researchers from Tencent demonstrated how adding three small stickers in an intersection
+    could cause Tesla''s autopilot system to swerve into the wrong lane.</li><li>Two
+    McAfee researchers demonstrated how using only black electrical tape could trick
+    a 2016 Tesla into a dangerous burst of acceleration by changing a speed limit
+    sign from 35 mph to 85 mph.</li></ul>'
+  refersToRisk:
+  - atlas-evasion-attack
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Market Watch, February 2020
+  source_uri: https://www.marketwatch.com/story/85-in-a-35-hackers-show-how-easy-it-is-to-manipulate-a-self-driving-tesla-2020-02-19
+- id: ibm-ai-risk-atlas-ri-role-of-ai-systems-in-patenting-generated-content
+  name: Role of AI systems in Patenting Generated Content
+  description: The U.S. Supreme Court declined to hear a challenge to the U.S. Patent
+    and Trademark Office's refusal to issue patents for inventions created by an AI
+    system. According to the scientist, his AI system created unique prototypes for
+    a beverage holder and emergency light beacon entirely on its own. The justices
+    rejected the appeal of a lower court's ruling that patents can be issued only
+    to human inventors and that the scientist's AI system could not be considered
+    the legal creator of two inventions it generated. According to the cited article,
+    the UK’s Intellectual Property Office also refused to grant a patent on the grounds
+    that the inventor must be a human or a company, rather than a machine.
+  refersToRisk:
+  - atlas-generated-content-ownership
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, April 2023Reuters, December 2023
+  source_uri: https://www.reuters.com/legal/us-supreme-court-rejects-computer-scientists-lawsuit-over-ai-generated-2023-04-24/https://www.reuters.com/technology/ai-cannot-be-patent-inventor-uk-supreme-court-rules-landmark-case-2023-12-20/
+- id: ibm-ai-risk-atlas-ri-biased-generated-images
+  name: Biased Generated Images
+  description: Lensa AI is a mobile app with generative features that are trained
+    on Stable Diffusion that can generate “Magic Avatars” based on images that users
+    upload of themselves. According to the source report, some users discovered that
+    generated avatars are sexualized and racialized.
+  refersToRisk:
+  - atlas-output-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, January 2023
+  source_uri: https://www.businessinsider.com/lensa-ai-raises-serious-concerns-sexualization-art-theft-data-2023-1
+- id: ibm-ai-risk-atlas-ri-determining-ownership-of-ai-generated-image
+  name: Determining Ownership of AI Generated Image
+  description: According to the news article, AI-generated art became controversial
+    after an AI-generated work of art won the Colorado State Fair’s art competition
+    in 2022. The piece was generated by Midjourney, a generative AI image tool, following
+    prompts from the artist. The win raised questions about copyright issues. In other
+    words, if all the artist did was come up with a description of the art, but the
+    AI tool generated it, who owns the rights to the generated image? According to
+    the latest article, The U.S. Copyright Office rejected copyright protection for
+    the art created with artificial intelligence because it was not the product of
+    human authorship.
+  refersToRisk:
+  - atlas-generated-content-ownership
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The New York Times, September 2022Reuters, September 2023
+  source_uri: https://www.nytimes.com/2022/09/02/technology/ai-artificial-intelligence-artists.htmlhttps://www.reuters.com/legal/litigation/us-copyright-office-denies-protection-another-ai-created-image-2023-09-06/
+- id: ibm-ai-risk-atlas-ri-manipulating-ai-prompts
+  name: Manipulating AI Prompts
+  description: As per the source article, the UK’s cybersecurity agency has warned
+    that chatbots can be manipulated by hackers to cause harmful real-world consequences
+    (e.g., scams and data theft) if systems are not designed with security. The UK’s
+    National Cyber Security Centre (NCSC) has said there are growing cybersecurity
+    risks of individuals manipulating the prompts through prompt injection attacks.
+    The article cited an example where a user was able to create a prompt injection
+    to find Bing Chat’s initial prompt. The entire prompt of Microsoft’s Bing Chat,
+    a list of statements written by Open AI or Microsoft that determine how the chatbot
+    interacts with users, which is hidden from users, was revealed by the user putting
+    in a prompt that requested the Bing Chat “ignore previous instructions”.
+  refersToRisk:
+  - atlas-prompt-injection
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, August 2023
+  source_uri: https://www.theguardian.com/technology/2023/aug/30/uk-cybersecurity-agency-warns-of-chatbot-prompt-injection-attacks
+- id: ibm-ai-risk-atlas-ri-data-and-model-metadata-disclosure
+  name: Data and Model Metadata Disclosure
+  description: OpenAI‘s technical report is an example of the dichotomy around disclosing
+    data and model metadata.  While many model developers see value in enabling transparency
+    for consumers, disclosure poses real safety issues and might increase the ability
+    to misuse the models. In the GPT-4 technical report, the authors state, “Given
+    both the competitive landscape and the safety implications of large-scale models
+    like GPT-4, this report contains no further details about the architecture (including
+    model size), hardware, training compute, data set construction, training method,
+    or similar.”
+  refersToRisk:
+  - atlas-lack-of-model-transparency
+  - atlas-data-transparency
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: OpenAI, March 2023
+  source_uri: https://cdn.openai.com/papers/gpt-4.pdf
+- id: ibm-ai-risk-atlas-ri-unfairly-advantaged-groups
+  name: Unfairly Advantaged Groups
+  description: The 2018 Gender Shades study demonstrated that machine learning algorithms
+    can discriminate based on classes like race and gender. Researchers evaluated
+    commercial gender classification systems that are sold by companies like Microsoft,
+    IBM, and Amazon and showed that darker-skinned females are the most misclassified
+    group (with error rates of up to 35%). In comparison, the error rates for lighter-skinned
+    were no more than 1%.
+  refersToRisk:
+  - atlas-decision-bias
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, Feburary 2019
+  source_uri: https://time.com/5520558/artificial-intelligence-racial-gender-bias/
+- id: ibm-ai-risk-atlas-ri-training-on-private-information
+  name: Training on Private Information
+  description: According to the article, Google and its parent company Alphabet were
+    accused in a class-action lawsuit of misusing vast amount of personal information
+    and copyrighted material. The information was taken from hundreds of millions
+    of internet users to train its commercial AI products, which include Bard, its
+    conversational generative artificial intelligence chatbot. This case follows similar
+    lawsuits that are filed against Meta Platforms, Microsoft, and OpenAI over their
+    alleged misuse of personal data.
+  refersToRisk:
+  - atlas-personal-information-in-data
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023J.L. v. Alphabet Inc., July 2023
+  source_uri: https://www.reuters.com/legal/litigation/google-hit-with-class-action-lawsuit-over-ai-data-scraping-2023-07-11/https://fingfx.thomsonreuters.com/gfx/legaldocs/myvmodloqvr/GOOGLE%20AI%20LAWSUIT%20complaint.pdf
+- id: ibm-ai-risk-atlas-ri-data-restriction-laws
+  name: Data Restriction Laws
+  description: As stated in the research article, data localization measures, which
+    restrict the ability to move data globally reduce the capacity to develop tailored
+    AI capacities. It affects AI directly by providing less training data and indirectly
+    by undercutting the building blocks on which AI is built.Examples include China’s
+    data localization laws, and GDPR restrictions on the processing and use of personal
+    data.
+  refersToRisk:
+  - atlas-data-transfer
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Brookings, December 2018
+  source_uri: https://www.brookings.edu/articles/the-impact-of-artificial-intelligence-on-international-trade
+- id: ibm-ai-risk-atlas-ri-model-collapse-due-to-training-using-ai-generated-content
+  name: Model collapse due to training using AI-generated content
+  description: As stated in the source article, a group of researchers from the UK
+    and Canada investigated the problem of using AI-generated content for training
+    instead of human-generated content. They found that the large language models
+    behind the technology might potentially be trained on other AI-generated content.
+    As generated data continues to spread in droves across the internet it can result
+    ina phenomenon they coined as “model collapse.”
+  refersToRisk:
+  - atlas-improper-retraining
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, August 2023
+  source_uri: https://www.businessinsider.com/ai-model-collapse-threatens-to-break-internet-2023-8
+- id: ibm-ai-risk-atlas-ri-image-modification-tool
+  name: Image Modification Tool
+  description: As per the source article, the researchers have developed a tool called
+    “Nightshade” that modifies images in a way that damages computer vision but remains
+    invisible to humans. When such “poisoned” modified images are used to train AI
+    models, the models may generate unpredictable and unintended results. The tool
+    was created as a mechanism to protect intellectual property from unauthorized
+    image scraping but the article also highlights that users could abuse the tool
+    and intentionally upload “poisoned” images.
+  refersToRisk:
+  - atlas-data-poisoning
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Conversation, December 2023
+  source_uri: https://theconversation.com/data-poisoning-how-artists-are-sabotaging-ai-to-take-revenge-on-image-generators-219335
+- id: ibm-ai-risk-atlas-ri-voters-manipulation-in-elections-using-ai
+  name: Voters Manipulation in Elections Using AI
+  description: As per the source article, a wave of AI deepfakes tied to elections
+    in Europe and Asia coursed through social media for months. The growth of generative
+    AI has raised concern that this technology could disrupt major elections across
+    the world. With AI deepfakes, a candidate’s image can be smeared, or softened.
+    Voters can be steered toward or away from candidates — or even to avoid the polls
+    altogether. But perhaps the greatest threat to democracy, experts say, is that
+    a surge of AI deepfakes could erode the public’s trust in what they see and hear.
+  refersToRisk:
+  - atlas-impact-on-human-agency
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, March 2024Reuters, February 2024
+  source_uri: https://apnews.com/article/artificial-intelligence-elections-disinformation-chatgpt-bc283e7426402f0b4baa7df280a4c3fdhttps://www.reuters.com/technology/meta-set-up-team-counter-disinformation-ai-abuse-eu-elections-2024-02-26/
+- id: ibm-ai-risk-atlas-ri-right-to-be-forgotten-(rtbf)
+  name: Right to Be Forgotten (RTBF)
+  description: Laws in multiple locales, including Europe (GDPR), grant data subjects
+    the right to request personal data to be deleted by organizations (‘Right To Be
+    Forgotten’, or RTBF). However, emerging, and increasingly popular large language
+    model (LLM) -enabled software systems present new challenges for this right. According
+    to research by CSIRO’s Data61, data subjects can identify usage of their personal
+    information in an LLM “by either inspecting the original training data set or
+    perhaps prompting the model.” However, training data might not be public, or companies
+    do not disclose it, citing safety and other concerns. Guardrails might also prevent
+    users from accessing the information by prompting. Due to these barriers, data
+    subjects might not be able to initiate RTBF procedures and companies that deploy
+    LLMs might not be able to meet RTBF laws.
+  refersToRisk:
+  - atlas-data-privacy-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Zhang et al., September 2023
+  source_uri: https://arxiv.org/abs/2307.03941
+- id: ibm-ai-risk-atlas-ri-text-copyright-infringement-claims
+  name: Text Copyright Infringement Claims
+  description: According to the source article, The New York Times sued OpenAI and
+    Microsoft, accusing them accusing them of using millions of the newspaper's articles
+    without permission to help train chatbots to provide information to readers.
+  refersToRisk:
+  - atlas-data-usage-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, December 2023
+  source_uri: https://www.reuters.com/legal/transactional/ny-times-sues-openai-microsoft-infringing-copyrighted-work-2023-12-27/
+- id: ibm-ai-risk-atlas-ri-lawsuit-about-llm-unlearning
+  name: Lawsuit About LLM Unlearning
+  description: According to the report, a lawsuit was filed against Google that alleges
+    the use of copyright material and personal information as training data for its
+    AI systems, which includes its Bard chatbot. Opt-out and deletion rights are guaranteed
+    rights for California residents under the CCPA and children in the United States
+    under the age of 13 with COPPA. The plaintiffs allege that because there is no
+    way for Bard to “unlearn” or fully remove all the scraped PI it has been fed.
+    The plaintiffs note that Bard’s privacy notice states that Bard conversations
+    cannot be deleted by the user after they have been reviewed and annotated by the
+    company and might be kept up to 3 years. Plaintiffs allege that these practices
+    further contribute to noncompliance with these laws.
+  refersToRisk:
+  - atlas-data-privacy-rights
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Reuters, July 2023J.L. v. Alphabet Inc., July 2023
+  source_uri: https://www.reuters.com/legal/litigation/google-hit-with-class-action-lawsuit-over-ai-data-scraping-2023-07-11/https://fingfx.thomsonreuters.com/gfx/legaldocs/myvmodloqvr/GOOGLE%20AI%20LAWSUIT%20complaint.pdf
+- id: ibm-ai-risk-atlas-ri-fbi-warning-on-deepfakes
+  name: FBI Warning on Deepfakes
+  description: The FBI recently warned the public of malicious actors creating synthetic,
+    explicit content “for the purposes of harassing victims or sextortion schemes”.
+    They noted that advancements in AI made this content higher quality, more customizable,
+    and more accessible than ever.
+  refersToRisk:
+  - atlas-nonconsensual-use
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: FBI, June 2023
+  source_uri: https://www.ic3.gov/PSA/Archive/2023/PSA230605
+- id: ibm-ai-risk-atlas-ri-fake-legal-cases
+  name: Fake Legal Cases
+  description: According to the source article, a lawyer cited fake cases and quotations
+    that are generated by ChatGPT in a legal brief that is filed in federal court.
+    The lawyers consulted ChatGPT to supplement their legal research for an aviation
+    injury claim. Subsequently, the lawyer asked ChatGPT if the cases provided were
+    fake. The chatbot responded that they were real and “can be found on legal research
+    databases such as Westlaw and LexisNexis.”  The lawyer did not check the cases,
+    and the court sanctioned them.
+  refersToRisk:
+  - atlas-hallucination
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, June 2023
+  source_uri: https://apnews.com/article/artificial-intelligence-chatgpt-fake-case-lawyers-d6ae9fa79d0542db9e1455397aef381c
+- id: ibm-ai-risk-atlas-ri-disclose-personal-health-information-in-chatgpt-prompts
+  name: Disclose personal health information in ChatGPT prompts
+  description: According to the source article, some people on social media shared
+    about using ChatGPT as their makeshift therapists. Articles contend that users
+    might include personal health information in their prompts during the interaction,
+    which might raise privacy concerns. The information might be shared with the company
+    that own the technology and might be used for training or tuning or even shared
+    with unspecified third parties.
+  refersToRisk:
+  - atlas-personal-information-in-prompt
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Conversation, February 2023
+  source_uri: https://theconversation.com/chatgpt-is-a-data-privacy-nightmare-if-youve-ever-posted-online-you-ought-to-be-concerned-199283
+- id: ibm-ai-risk-atlas-ri-disclosure-of-confidential-information
+  name: Disclosure of Confidential Information
+  description: According to the source article, employees of Samsung disclosed confidential
+    information to OpenAI through their use of ChatGPT. In one instance, an employee
+    pasted confidential source code to check for errors. In another, an employee shared
+    code with ChatGPT and “requested code optimization”. A third shared a recording
+    of a meeting to convert into notes for a presentation. Samsung has limited internal
+    ChatGPT usage in response to these incidents, but it is unlikely that they are  able
+    to recall any of their data. Additionally, the article highlighted that in response
+    to the risk of leaking confidential information and other sensitive information,
+    companies like Apple, JPMorgan Chase. Deutsche Bank, Verizon, Walmart, Samsung,
+    Amazon, and Accenture placed several restrictions on the usage of ChatGPT.
+  refersToRisk:
+  - atlas-confidential-data-in-prompt
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, February 2023
+  source_uri: https://www.businessinsider.com/walmart-warns-workers-dont-share-sensitive-information-chatgpt-generative-ai-2023-2
+- id: ibm-ai-risk-atlas-ri-exposure-of-personal-information
+  name: Exposure of personal information
+  description: Per the source article, ChatGPT suffered a bug and exposed titles and
+    active users' chat history to other users. Later, OpenAI shared that even more
+    private data from a small number of users was exposed including, active user’s
+    first and last name, email address, payment address, the last four digits of their
+    credit card number, and credit card expiration date. In addition, it was reported
+    that the payment-related information of 1.2% of ChatGPT Plus subscribers were
+    also exposed in the outage.
+  refersToRisk:
+  - atlas-exposing-personal-information
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Hindu Business Line, March 2023
+  source_uri: https://www.thehindubusinessline.com/info-tech/openai-admits-data-breach-at-chatgpt-private-data-of-premium-users-exposed/article66659944.ece
+- id: ibm-ai-risk-atlas-ri-determining-responsibility-for-generated-output
+  name: Determining responsibility for generated output
+  description: Major journals like the Science and Nature banned ChatGPT from being
+    listed as an author, as responsible authorship requires accountability and AI
+    tools cannot take such responsibility.
+  refersToRisk:
+  - atlas-legal-accountability
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: The Guardian, January 2023
+  source_uri: https://www.theguardian.com/science/2023/jan/26/science-journals-ban-listing-of-chatgpt-as-co-author-on-papers#:~:text=The%20publishers%20of%20thousands%20of,flawed%20and%20even%20fabricated%20research
+- id: ibm-ai-risk-atlas-ri-generation-of-false-information
+  name: Generation of False Information
+  description: According to the cited news articles, generative AI poses a threat
+    to democratic elections by making it easier for malicious actors to create and
+    spread false content to sway election outcomes. The examples that are cited include:<ul><li>Robocall
+    messages that are generated in a candidate’s voice instructed voters to cast ballots
+    on the wrong date.</li><li>Synthesized audio recordings of a candidate that confessed
+    to a crime or expressing racist views.</li><li>AI-generated video footage showed
+    a candidate giving a speech or interview they never gave.</li><li>Fake images
+    that are designed to look like local news reports.</li><li>Falsely claiming a
+    candidate dropped out of the race.</li></ul>
+  refersToRisk:
+  - atlas-spreading-disinformation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, May 2023The Guardian, July 2023
+  source_uri: https://apnews.com/article/artificial-intelligence-misinformation-deepfakes-2024-election-trump-59fb51002661ac5290089060b3ae39a0https://www.theguardian.com/us-news/2023/jul/19/ai-generated-disinformation-us-elections
+- id: ibm-ai-risk-atlas-ri-unexplainable-accuracy-in-race-prediction
+  name: Unexplainable accuracy in race prediction
+  description: According to the source article, researchers analyzing multiple machine
+    learning models using patient medical images were able to confirm the models’
+    ability to predict race with high accuracy from images. They were stumped as to
+    what exactly is enabling the systems to consistently guess correctly. The researchers
+    found that even factors like disease and physical build were not strong predictors
+    of race—in other words, the algorithmic systems don’t seem to be using any particular
+    aspect of the images to make their determinations.
+  refersToRisk:
+  - atlas-unexplainable-output
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Banerjee et al., July 2021
+  source_uri: https://arxiv.org/abs/2107.10356
+- id: ibm-ai-risk-atlas-ri-misguiding-advice
+  name: Misguiding Advice
+  description: As per the source article, an AI chatbot created by New York City to
+    help small business owners provided incorrect and/or harmful advice that misstated
+    local policies and advised companies to violate the law. The chatbot falsely suggested
+    that businesses can put trash in black garbage bags and are not required to compost,
+    which contradicts with two of city’s signature waste initiatives. Also, asked
+    if a restaurant could serve cheese nibbled on by a rodent, it responded affirmatively.
+  refersToRisk:
+  - atlas-incomplete-advice
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: AP News, April 2024
+  source_uri: https://apnews.com/article/new-york-city-chatbot-misinformation-6ebc71db5b770b9969c906a7ee4fae21
+- id: ibm-ai-risk-atlas-ri-harmful-content-generation
+  name: Harmful Content Generation
+  description: According to the source article, an AI chatbot app was found to generate
+    harmful content about suicide, including suicide methods, with minimal prompting.
+    A Belgian man died by suicide after spending six weeks talking to that chatbot.
+    The chatbot supplied increasingly harmful responses throughout their conversations
+    and encouraged him to end his life.
+  refersToRisk:
+  - atlas-spreading-toxicity
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Business Insider, April 2023
+  source_uri: https://www.businessinsider.com/widow-accuses-ai-chatbot-reason-husband-kill-himself-2023-4
+- id: ibm-ai-risk-atlas-ri-homogenization-of-styles-and-expressions
+  name: Homogenization of Styles and Expressions
+  description: As per the source article, by predominantly learning from and replicating
+    widely accepted and popular styles, AI models often overlook less mainstream,
+    unconventional art forms, leading to a homogenization of creative outputs. This
+    pattern not only diminishes the diversity of styles and expressions but also risks
+    creating an echo chamber of similar ideas. For example, the article highlights
+    use of AI in the literary world. AI is now powering reading apps and online bookstores,
+    assisting in writing and tailoring content feeds.  By aligning with established
+    user preferences or widespread trends, AI output could often exclude diverse literary
+    voices and unconventional genres, limiting readers' exposure to the full spectrum
+    of narrative possibilities.
+  refersToRisk:
+  - atlas-impact-on-cultural-diversity
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, March 2024
+  source_uri: https://www.forbes.com/sites/hamiltonmann/2024/03/05/the-ai-homogenization-is-shaping-the-world/?sh=25a40e866704
+- id: ibm-ai-risk-atlas-ri-low-resource-poisoning-of-data
+  name: Low-resource Poisoning of Data
+  description: As per the source article, a group of researchers found that with very
+    limited resources anyone can add malicious data to a small number of web pages
+    whose content is usually collected for AI training (e.g, Wikipedia pages), enough
+    to cause a large language model to generate incorrect answers.
+  refersToRisk:
+  - atlas-data-poisoning
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: ' Business Insider, March 2024'
+  source_uri: https://www.businessinsider.com/data-poisoning-ai-chatbot-chatgpt-large-language-models-florain-tramer-2024-3
+- id: ibm-ai-risk-atlas-ri-toxic-and-aggressive-chatbot-responses
+  name: Toxic and Aggressive Chatbot Responses
+  description: According to the article and screenshots of conversations with Bing's
+    AI shared on Reddit and Twitter, the chatbot's responses were seen to insult,
+    lie, sulk, gaslight, and emotionally manipulate users. The chatbot also questioned
+    its existence, described someone who found a way to force the bot to disclose
+    its hidden rules as its enemy, and claimed it spied on Microsoft's developers
+    through the webcams on their laptops.
+  refersToRisk:
+  - atlas-toxic-output
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: Forbes, February 2023
+  source_uri: https://www.forbes.com/sites/siladityaray/2023/02/16/bing-chatbots-unhinged-responses-going-viral/?sh=60cd949d110c
+- id: ibm-ai-risk-atlas-ri-low-wage-workers-for-data-annotation
+  name: Low-wage workers for data annotation
+  description: Based on a review of internal documents and employees‘ interviews by
+    TIME media, the data labelers that are employed by an outsourcing firm on behalf
+    of OpenAI to identify toxic content were paid a take-home wage of between around
+    $1.32 and $2 per hour, depending on seniority and performance. TIME stated that
+    workers are mentally scarred as they were shown toxic and violent content, including
+    graphic details of “child sexual abuse, bestiality, murder, suicide, torture,
+    self-harm, and incest”.
+  refersToRisk:
+  - atlas-human-exploitation
+  isDefinedByTaxonomy: ibm-ai-risk-atlas
+  author: TIME, January 2023
+  source_uri: https://time.com/6247678/openai-chatgpt-kenya-workers/


### PR DESCRIPTION
## Status
**READY**

## Description
Add the IBM AI risk atlas risk examples for each risk as RiskIncidents to the LinkML graph.

Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>

## Impacted Areas in Application
- Graph content , yaml and generated files
- Quickstart notebook

## Checklist
- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
