### PR TITLE
fix: add full urls for broken links in notebook

### DIFF
--- a/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
+++ b/docs/examples/notebooks/Risk_Atlas_Nexus_Quickstart.ipynb
@@ -42,8 +42,8 @@
     "You can use the python library methods to quickly explore available risks, relations and actions, as well as to detect potential risks in your usecase.\n",
     "\n",
     "Important references:\n",
-    "- [LinkML schema documentation](../../../docs/ontology/index.md)\n",
-    "- [LinkML instance data for an example knowledge graph](../../../src/risk_atlas_nexus/data/knowledge_graph/README.md)"
+    "- [LinkML schema documentation](https://ibm.github.io/risk-atlas-nexus/ontology/)\n",
+    "- [LinkML instance data for an example knowledge graph](https://github.com/IBM/risk-atlas-nexus/blob/main/src/risk_atlas_nexus/data/knowledge_graph/README.md)"
    ]
   },
   {


### PR DESCRIPTION
## Status
**READY**

## Description
Fix 2 broken links in the quick star notebook, detailed in issue #78 

Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>

## Impacted Areas in Application
Documentation 

### Screenshots
<!-- For UI items, please provide screenshots demonstrating the work completed -->

## Which issue(s) does this pull-request fix?
Closes: IBM/risk-atlas-nexus#78
issue #78 

## Any special notes for your reviewer?
