### PR TITLE
Use Few-shot only when examples are provided by users.

### DIFF
--- a/src/risk_atlas_nexus/library.py
+++ b/src/risk_atlas_nexus/library.py
@@ -500,10 +500,9 @@ class RiskAtlasNexus:
             taxonomy (str, optional):
                 The string label for a taxonomy.
             cot_examples (Dict[str, List], optional):
-                The Chain of Thought (CoT) examples to use in the risk identification.
+                The Chain of Thought (CoT) examples to use in Few-Shot risk identification. If this parameter is None, the API defaults to a Zero-Shot method.
                 The example template is available at src/risk_atlas_nexus/data/templates/risk_generation_cot.json.
-                Assign the ID of the taxonomy you wish to use as the key for CoT examples. Providing this value
-                will override the CoT examples present in the template master. Default to None.
+                Assign the ID of the taxonomy you wish to use as the key for CoT examples.
             max_risk (int, optional):
                 The maximum number of risks to extract. Pass None to allow the inference engine to determine the number of risks. Defaults to None.
 
@@ -541,17 +540,6 @@ class RiskAtlasNexus:
             "Usecases must be a list of string.",
         )
 
-        # For the given taxonomy type, check if the user has provided 'cot_examples'. If not,
-        # retrieve the default cot examples from the master. If no examples exist in the master,
-        # set it as None.
-        RISK_IDENTIFICATION_COT = load_resource("risk_generation_cot.json")
-        processed_examples = None
-
-        if cot_examples:
-            processed_examples = cot_examples.get(taxonomy, None)
-        elif taxonomy:
-            processed_examples = RISK_IDENTIFICATION_COT.get(taxonomy, None)
-
         # if not providing taxonomy, set to IBM AI risk atlas
         if taxonomy is None:
             logger.warning(
@@ -561,14 +549,11 @@ class RiskAtlasNexus:
 
         set_taxonomy = taxonomy or "ibm-ai-risk-atlas"
 
-        # Set prompt builder based on whether the CoT examples are available.
-        if processed_examples is None:
-            logger.warning(
-                f"<RAN47275F12W>",
-                f"Warning: Chain of Thought (CoT) examples were not provided, or do not exist in the master for this "
-                f"taxonomy. The API will use the Zero shot method. To improve the accuracy "
-                f"of risk identification, please provide CoT examples in `cot_examples` when calling this API. You may "
-                f"also consider raising an issue to permanently add these examples to the Risk Atlas Nexus master.",
+        # For the given taxonomy type, check if the user has provided `cot_examples`.
+        processed_examples = cot_examples and cot_examples.get(set_taxonomy, None)
+        if processed_examples:
+            logger.info(
+                f"Chain of Thought (CoT) examples were identified for the taxonomy: {set_taxonomy}. The API will employ the Few-Shot method. To improve the accuracy of risk identification, please provide relevant CoT examples.",
             )
 
         risk_detector = GenericRiskDetector(


### PR DESCRIPTION


## Status
**READY**

## Description
The Chain of Thought (CoT) examples have a significantly greater impact on risk generation, even outweighing the effects of different temperature values. As mentioned in the issue below, the system assigns the same risk labels regardless of the temperature settings. 

Therefore, the system should no longer use CoT examples from the master list when CoT examples are not available.

## Which issue(s) does this pull-request fix?
https://github.com/IBM/risk-atlas-nexus/issues/77
