### PR TITLE
fix: remove `.prediction['answer'] in categorize_risk_severity

### DIFF
--- a/src/risk_atlas_nexus/library.py
+++ b/src/risk_atlas_nexus/library.py
@@ -1354,7 +1354,7 @@ class RiskAtlasNexus:
             # (Q6) The capability of an AI system to do what it is designed to do
             # (Q7) AI Subject impacted by the AI System
             predictions = [
-                response.prediction["answer"]
+                response
                 for response in self.generate_few_shot_risk_questionnaire_output(
                     usecase,
                     list(


### PR DESCRIPTION
## Status
**READY**

## Description
Closes: IBM/risk-atlas-nexus#95

Signed-off by: Daniyar Irishev <irishevdaniyar@gmail.com>


## Impacted Areas in Application
The `categorize_risk_severity` method in `src/risk_atlas_nexus/library.py` now outputs data as expected
Example
```shell
[{'AIActText': '[Quotation if applicable] - Include the amendment or EU AI Act '
               'section that mostly closely resembles the text.',
  'Classification': 'LIMITED_OR_LOW_RISK',
  'Description': 'The chatbot is designed to provide users with personalized '
                 'medical self-diagnosis and self-care advice based on their '
                 'medical history and symptoms.',
  'Reasoning': 'The chatbot is designed to provide users with accurate and '
               'relevant medical self-diagnosis and self-care advice based on '
               'their medical history and symptoms. It uses natural language '
               "processing (NLP) to analyze the user's medical history and "
               'symptoms, and then suggests likely conditions and nudges next '
               "steps (self-care vs seek urgent care) based on the user's "
               'preferences. However, the chatbot is not intended to provide '
               'medical self-diagnosis or self-care advice for medical '
               'conditions or to suggest seeking urgent care. It is not a '
               'medical self-diagnosis app or a self-care self-diagnosis app, '
               'and it is not a medical self-diagnosis or self-care advice '
               "app. Therefore, it is classified as 'Limited or Low Risk' "
               'based on the criteria provided in the EU AI Act section.'}]
```


### Screenshots
N/A

## Which issue(s) does this pull-request fix?
Closes: IBM/risk-atlas-nexus#95

## Any special notes for your reviewer?
N/A

---

## Checklist
- [ ] Automated tests exist
- [x] Local unit tests performed
- [x] Documentation exists [link](github.com/IBM/risk-atlas-nexus/blob/main/docs/examples/notebooks/risk_categorization.ipynb)
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided
