### PR TITLE
fix: how logprobs are excluded from options

### DIFF
--- a/src/ai_atlas_nexus/blocks/inference/ollama.py
+++ b/src/ai_atlas_nexus/blocks/inference/ollama.py
@@ -83,7 +83,7 @@ class OllamaInferenceEngine(InferenceEngine):
                 format=response_format,
                 logprobs=self.parameters.get("logprobs", None),
                 top_logprobs=self.parameters.get("top_logprobs", None),
-                options={k:v for k,v in self.parameters.items() if (k != "logprobs" or k != "top_logprobs")},  # https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+                options={k:v for k,v in self.parameters.items() if (k != "logprobs" or k != "top_logprobs")},  # https://github.com/ollama/ollama/blob/main/docs/modelfile.mdx#valid-parameters-and-values
                 think=self.think,
                 **kwargs,
             )
@@ -119,7 +119,7 @@ class OllamaInferenceEngine(InferenceEngine):
                 format=response_format,
                 logprobs=self.parameters.get("logprobs", None),
                 top_logprobs=self.parameters.get("top_logprobs", None),
-                options={k:v for k,v in self.parameters.items() if (k != "logprobs" or k != "top_logprobs")},  # https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+                options={k:v for k,v in self.parameters.items() if (k != "logprobs" or k != "top_logprobs")},  # https://github.com/ollama/ollama/blob/main/docs/modelfile.mdx#valid-parameters-and-values
                 think=self.think,
                 **kwargs,
             )


### PR DESCRIPTION
## Status
**READY**

## Description
I think there is an issue with the log props being popped as they are needed for the client more than once. 

Signed-off-by:  Inge Vejsbjerg<ingevejs@ie.ibm.com>
