### PR TITLE
fix(export_cypher): workaround double-double-quotes issue

### DIFF
--- a/src/ai_atlas_nexus/data/knowledge_graph/principles_australia.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/principles_australia.yaml
@@ -2,10 +2,10 @@ documents:
 - id: doc-australia-ai-ethics-principles
   name: "Australia's AI Ethics Principles"
   description: >-
-    "Australia's 8 Artificial Intelligence (AI) Ethics Principles are designed to ensure AI is safe, secure and reliable.
+    Australia's 8 Artificial Intelligence (AI) Ethics Principles are designed to ensure AI is safe, secure and reliable.
     They will help: achieve safer, more reliable and fairer outcomes for all Australians; reduce the risk of negative
     impact on those affected by AI applications; businesses and governments to practice the highest ethical standards
-    when designing, developing and implementing AI."
+    when designing, developing and implementing AI.
   url: https://www.industry.gov.au/publications/australias-artificial-intelligence-ethics-principles/australias-ai-ethics-principles
   dateCreated: 2024-10-11
 

--- a/src/ai_atlas_nexus/data/knowledge_graph/risk_atlas_data.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/risk_atlas_data.yaml
@@ -1420,10 +1420,10 @@ risks:
   type: training-data
   descriptor:
   - amplified by generative AI
-  concern: '"There are several ways of collecting data for building a foundation models:
+  concern: There are several ways of collecting data for building a foundation models:
     web scraping, web crawling, crowdsourcing, and curating public datasets. Data
     acquisition restrictions can also impact the availability of the data that is
-    required for training an AI model and can lead to poorly represented data."'
+    required for training an AI model and can lead to poorly represented data.
 - id: atlas-sharing-info-tools-agentic
   name: Sharing IP/PI/confidential information with tools
   description: AI agents with unrestricted access to resources or databases or tools


### PR DESCRIPTION
This PR removes quotes from some `description` fields in four yaml files from `knowledge_graph/` directory.

---
## Status
**READY*

## Description
<!-- Commit Message Description
```
# When opening this PR, the raiser should replace this text with the remaining lines of their desired commit message, e.g:

Further details of the code going into the commit

Closes: IBM/ai-atlas-nexus#134

Signed-off-by: Your Name <email@ie.ibm.com>
```
* The reviewer should copy the above text into the extended description field when performing the `squash and merge` from this page.
-->

## Impacted Areas in Application
Some Data Knowledge Graph files

### Screenshots


## Which issue(s) does this pull-request fix?
https://github.com/IBM/ai-atlas-nexus/issues/134

## Any special notes for your reviewer?

Please review issue #134 to decide if this is fix or workaround.

---

## Checklist
- [ ] Automated tests exist
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local git lint performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
