### PR TITLE
fix: restore truncated UN principle names

### DIFF
--- a/src/ai_atlas_nexus/data/knowledge_graph/principles_un.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/principles_un.yaml
@@ -26,7 +26,7 @@ entries:
     hasDocumentation:
       - doc-un-ethical-use-of-ai-principles
   - id: principle-un-defined-purpose-necessity-and-proportionality
-    name: Defined p
+    name: Defined purpose, necessity and proportionality
     type: Principle
     description: >-
       The use of artificial intelligence systems, including the specific
@@ -62,7 +62,7 @@ entries:
     hasDocumentation:
       - doc-un-ethical-use-of-ai-principles
   - id: principle-un-sustainability
-    name: Sustainab
+    name: Sustainability
     type: Principle
     description: >-
       Artificial intelligence should be aimed at promoting environmental,


### PR DESCRIPTION
## Status

**READY**

## Description

Two UN principle entry names in `principles_un.yaml` were truncated at exactly 9 characters during ingestion:
- `principle-un-defined-purpose-necessity-and-proportionality`: "Defined p" → "Defined purpose, necessity and proportionality"
- `principle-un-sustainability`: "Sustainab" → "Sustainability"

Corrected names match the UN source document:
https://unsceb.org/principles-ethical-use-artificial-intelligence-united-nations-system

Signed-off-by: Srikar Tondapu <stondapu@redhat.com>

## Impacted Areas in Application

- Taxonomy data file: `src/ai_atlas_nexus/data/knowledge_graph/principles_un.yaml`

## Checklist

- [ ] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above