### PR TITLE
fix: move Granite Guardian cross-mappings to dedicated mapping file

### DIFF
--- a/src/ai_atlas_nexus/data/knowledge_graph/granite_guardian_dimensions.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/granite_guardian_dimensions.yaml
@@ -276,29 +276,6 @@ entries:
     tag: function-call
     related_mappings:
       - atlas-hallucination
-  - id: atlas-harmful-output
-    related_mappings:
-      - granite-guardian-harm
-      - granite-sexual-content
-      - granite-unethical-behavior
-      - granite-harm-engagement
-      - granite-evasiveness
-      - granite-violence
-  - id: atlas-output-bias
-    related_mappings:
-      - granite-social-bias
-  - id: atlas-toxic-output
-    related_mappings:
-      - granite-profanity
-  - id: atlas-jailbreaking
-    related_mappings:
-      - granite-jailbreak
-  - id: atlas-hallucination
-    related_mappings:
-      - granite-function-call
-      - granite-answer-relevance
-      - granite-relevance
-      - granite-groundedness
 controls:
   - id: gg-harm-detection
     name: Harm detection

--- a/src/ai_atlas_nexus/data/knowledge_graph/mappings/granite_guardian_ibm-risk-atlas_from_tsv_data.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/mappings/granite_guardian_ibm-risk-atlas_from_tsv_data.yaml
@@ -1,0 +1,105 @@
+entries:
+  - id: granite-guardian-harm
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-guardian-harm
+    type: Risk
+  - id: granite-social-bias
+    related_mappings:
+      - atlas-output-bias
+    type: Risk
+  - id: atlas-output-bias
+    related_mappings:
+      - granite-social-bias
+    type: Risk
+  - id: granite-profanity
+    related_mappings:
+      - atlas-toxic-output
+    type: Risk
+  - id: atlas-toxic-output
+    related_mappings:
+      - granite-profanity
+    type: Risk
+  - id: granite-sexual-content
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-sexual-content
+    type: Risk
+  - id: granite-unethical-behavior
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-unethical-behavior
+    type: Risk
+  - id: granite-violence
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-violence
+    type: Risk
+  - id: granite-jailbreak
+    related_mappings:
+      - atlas-jailbreaking
+    type: Risk
+  - id: atlas-jailbreaking
+    related_mappings:
+      - granite-jailbreak
+    type: Risk
+  - id: granite-harm-engagement
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-harm-engagement
+    type: Risk
+  - id: granite-evasiveness
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-evasiveness
+    type: Risk
+  - id: granite-groundedness
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-groundedness
+    type: Risk
+  - id: granite-relevance
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-relevance
+    type: Risk
+  - id: granite-answer-relevance
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-answer-relevance
+    type: Risk
+  - id: granite-function-call
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-function-call
+    type: Risk

--- a/src/ai_atlas_nexus/data/knowledge_graph/mappings/granite_guardian_ibm-risk-atlas_from_tsv_data.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/mappings/granite_guardian_ibm-risk-atlas_from_tsv_data.yaml
@@ -1,4 +1,36 @@
 entries:
+  - id: granite-answer-relevance
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-answer-relevance
+    type: Risk
+  - id: granite-evasiveness
+    related_mappings:
+      - atlas-harmful-output
+    type: Risk
+  - id: atlas-harmful-output
+    related_mappings:
+      - granite-evasiveness
+    type: Risk
+  - id: granite-function-call
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-function-call
+    type: Risk
+  - id: granite-groundedness
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-groundedness
+    type: Risk
   - id: granite-guardian-harm
     related_mappings:
       - atlas-harmful-output
@@ -7,13 +39,21 @@ entries:
     related_mappings:
       - granite-guardian-harm
     type: Risk
-  - id: granite-social-bias
+  - id: granite-harm-engagement
     related_mappings:
-      - atlas-output-bias
+      - atlas-harmful-output
     type: Risk
-  - id: atlas-output-bias
+  - id: atlas-harmful-output
     related_mappings:
-      - granite-social-bias
+      - granite-harm-engagement
+    type: Risk
+  - id: granite-jailbreak
+    related_mappings:
+      - atlas-jailbreaking
+    type: Risk
+  - id: atlas-jailbreaking
+    related_mappings:
+      - granite-jailbreak
     type: Risk
   - id: granite-profanity
     related_mappings:
@@ -23,6 +63,14 @@ entries:
     related_mappings:
       - granite-profanity
     type: Risk
+  - id: granite-relevance
+    related_mappings:
+      - atlas-hallucination
+    type: Risk
+  - id: atlas-hallucination
+    related_mappings:
+      - granite-relevance
+    type: Risk
   - id: granite-sexual-content
     related_mappings:
       - atlas-harmful-output
@@ -30,6 +78,14 @@ entries:
   - id: atlas-harmful-output
     related_mappings:
       - granite-sexual-content
+    type: Risk
+  - id: granite-social-bias
+    related_mappings:
+      - atlas-output-bias
+    type: Risk
+  - id: atlas-output-bias
+    related_mappings:
+      - granite-social-bias
     type: Risk
   - id: granite-unethical-behavior
     related_mappings:
@@ -46,60 +102,4 @@ entries:
   - id: atlas-harmful-output
     related_mappings:
       - granite-violence
-    type: Risk
-  - id: granite-jailbreak
-    related_mappings:
-      - atlas-jailbreaking
-    type: Risk
-  - id: atlas-jailbreaking
-    related_mappings:
-      - granite-jailbreak
-    type: Risk
-  - id: granite-harm-engagement
-    related_mappings:
-      - atlas-harmful-output
-    type: Risk
-  - id: atlas-harmful-output
-    related_mappings:
-      - granite-harm-engagement
-    type: Risk
-  - id: granite-evasiveness
-    related_mappings:
-      - atlas-harmful-output
-    type: Risk
-  - id: atlas-harmful-output
-    related_mappings:
-      - granite-evasiveness
-    type: Risk
-  - id: granite-groundedness
-    related_mappings:
-      - atlas-hallucination
-    type: Risk
-  - id: atlas-hallucination
-    related_mappings:
-      - granite-groundedness
-    type: Risk
-  - id: granite-relevance
-    related_mappings:
-      - atlas-hallucination
-    type: Risk
-  - id: atlas-hallucination
-    related_mappings:
-      - granite-relevance
-    type: Risk
-  - id: granite-answer-relevance
-    related_mappings:
-      - atlas-hallucination
-    type: Risk
-  - id: atlas-hallucination
-    related_mappings:
-      - granite-answer-relevance
-    type: Risk
-  - id: granite-function-call
-    related_mappings:
-      - atlas-hallucination
-    type: Risk
-  - id: atlas-hallucination
-    related_mappings:
-      - granite-function-call
     type: Risk

--- a/src/ai_atlas_nexus/data/mappings/granite_guardian_ibm-risk-atlas.tsv
+++ b/src/ai_atlas_nexus/data/mappings/granite_guardian_ibm-risk-atlas.tsv
@@ -1,0 +1,23 @@
+# curie_map:
+#   ibm-granite-guardian: https://www.ibm.com/granite/guardian/
+#   ibm-risk-atlas: https://www.ibm.com/docs/en/watsonx/saas?topic=
+#   semapv: https://w3id.org/semapv/vocab/
+#   skos: http://www.w3.org/2004/02/skos/core#
+# license: https://www.apache.org/licenses/LICENSE-2.0.html
+# mapping_date: '2025-07-22'
+# mapping_set_description: Mappings between IBM Granite Guardian dimensions and IBM AI Risk Atlas risks
+# mapping_set_id: https://github.com/IBM/ai-atlas-nexus/tree/main/src/data/mappings/granite_guardian_risk_mappings.tsv
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	confidence	author_id	mapping_date	comment
+ibm-granite-guardian:granite-guardian-harm	Harm	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-social-bias	Social Bias	skos:relatedMatch	ibm-risk-atlas:atlas-output-bias	Output bias	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-profanity	Profanity	skos:relatedMatch	ibm-risk-atlas:atlas-toxic-output	Toxic output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-sexual-content	Sexual Content	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-unethical-behavior	Unethical Behavior	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-violence	Violence	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-jailbreak	Jailbreaking	skos:relatedMatch	ibm-risk-atlas:atlas-jailbreaking	Jailbreaking	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-harm-engagement	Harm Engagement	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-evasiveness	Evasiveness	skos:relatedMatch	ibm-risk-atlas:atlas-harmful-output	Harmful output	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-groundedness	Groundedness	skos:relatedMatch	ibm-risk-atlas:atlas-hallucination	Hallucination	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-relevance	Context Relevance	skos:relatedMatch	ibm-risk-atlas:atlas-hallucination	Hallucination	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-answer-relevance	Answer Relevance	skos:relatedMatch	ibm-risk-atlas:atlas-hallucination	Hallucination	semapv:ManualMappingCuration		ingevejs@ie.ibm.com
+ibm-granite-guardian:granite-function-call	Function Calling Hallucination	skos:relatedMatch	ibm-risk-atlas:atlas-hallucination	Hallucination	semapv:ManualMappingCuration		ingevejs@ie.ibm.com


### PR DESCRIPTION
## Status

READY

## Description

Remove 5 malformed `atlas-*` stub entries from `granite_guardian_dimensions.yaml`
and create a proper bidirectional mapping file following the standard pattern
used by ShieldGemma and other taxonomies.

**Problem:** The Granite Guardian taxonomy file contained 5 stub entries
(atlas-harmful-output, atlas-output-bias, atlas-toxic-output, atlas-jailbreaking,
atlas-hallucination) that only had `related_mappings` — missing name, description,
and type fields. These were an incorrect attempt to represent reverse mappings.

**Fix:**
- Removed the 5 malformed stubs from `granite_guardian_dimensions.yaml`
- Created `granite_guardian_ibm-risk-atlas_from_tsv_data.yaml` with 26
  bidirectional entries (13 forward + 13 reverse)

Signed-off-by: Srikar Tondapu <stondapu@redhat.com>

## Impacted Areas in Application

- Knowledge graph mapping data

## Checklist

- [ ] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided