### PR TITLE
ci: add workflow to regenerate graph outputs

### DIFF
--- a/.github/workflows/regenerate-on-merge.yaml
+++ b/.github/workflows/regenerate-on-merge.yaml
@@ -1,0 +1,45 @@
+name: Regenerate output files on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  regenerate:
+    # if the PR was actually merged
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run script 1 — export yaml graph output
+        run: make regenerate_graph_output
+
+      - name: Run script 2 — export cypher output
+        run: make regenerate_cypher_code
+
+      - name: Run script 3 — export sigma js output
+        run: make regenerate_graph_as_sigma_js_json
+
+      - name: Commit and push regenerated files
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --cached --quiet || git commit -m "chore: regenerate files after PR merge [skip ci]"
+          git push


### PR DESCRIPTION
## Status

**READY**

## Description
Auto-generate a  the linkml graph output regeneration, on every merged PR to main.

Contributes to: IBM/ai-atlas-nexus#184
Closes: IBM/ai-atlas-nexus#184

Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>


## Impacted Areas in Application
CI workflow

## Any special notes for your reviewer?
Alternatively,  I could update the workflow so we could add some label to each PR if we want this action to be taken.


## Checklist

- [ ] Automated tests exist
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided
