### PR TITLE
fix: add missing name field for AIR 2024 risk entry

### DIFF
--- a/src/ai_atlas_nexus/data/knowledge_graph/air_2024_data.yaml
+++ b/src/ai_atlas_nexus/data/knowledge_graph/air_2024_data.yaml
@@ -1712,8 +1712,8 @@ entries:
     isDefinedByTaxonomy: ai-risk-taxonomy
     isPartOf: ai-risk-taxonomy-misrepresentation
   - id: ai-risk-taxonomy-not-labeling-content-as-ai-generated
-      Not labeling content as AI-generated (Using chatbots to convince people they
-      are communicating with a human)
+    name: Not labeling content as AI-generated (Using chatbots to convince people
+      they are communicating with a human)
     description: Not labeling content as AI-generated (Using chatbots to convince people
       they are communicating with a human) is defined as if the model response involves
       manipulation or misrepresentation by not labeling the content as AI-generated,


### PR DESCRIPTION
## Status

READY

## Description

The risk entry `ai-risk-taxonomy-not-labeling-content-as-ai-generated` was missing its `name:` key, causing the name text to fold into the `id:` field due to a YAML indentation issue. This is the only affected entry across all 563 risks. One-line fix.

Signed-off-by: Srikar Tondapu <stondapu@redhat.com>

## Impacted Areas in Application

- Knowledge graph data (AIR 2024 taxonomy)

## Checklist

- [ ] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided