### PR TITLE
fix: repair broken get_instances library method

### DIFF
--- a/src/ai_atlas_nexus/library.py
+++ b/src/ai_atlas_nexus/library.py
@@ -1993,7 +1993,7 @@ class AIAtlasNexus:
             "<RAN92358069E>",
             str,
             allow_none=False,
-            target_class=id,
+            target_class=target_class,
         )
         type_check(
             "<RAN61877043E>",
@@ -2002,8 +2002,8 @@ class AIAtlasNexus:
             taxonomy=taxonomy,
         )
 
-        instances: list[Any] = cls._atlas_explorer.get_instances(
-            target_class, taxonomy
+        instances: list[Any] = cls._atlas_explorer.get_all(
+            target_class, taxonomy=taxonomy
         )
         return instances
 

--- a/tests/ai_atlas_nexus/test_library.py
+++ b/tests/ai_atlas_nexus/test_library.py
@@ -143,6 +143,19 @@ class TestLibrary(TestCaseBase):
         all_actions = ran_lib.get_all_actions()
         self.assertIsInstance(all_actions, list)
 
+    def test_get_instances(self):
+        """Get instances of a class generically, filtered by taxonomy"""
+        ran_lib = self.ran_lib
+        instances = ran_lib.get_instances("risks", taxonomy="ibm-risk-atlas")
+        self.assertIsInstance(instances, list)
+        self.assertGreater(len(instances), 0)
+        assert instances[0].linkml_meta.root["class_uri"] == "airo:Risk"
+
+    def test_get_instances_target_class_not_a_str(self):
+        """Get instances of a class generically - target_class type is wrong"""
+        ran_lib = self.ran_lib
+        self.assertRaises(TypeError, ran_lib.get_instances, 123)
+
     def test_identify_risks_from_usecase_taxonomy_not_a_str(self):
         """Identify potential risks from a usecase description - taxonomy type is wrong"""
         ran_lib = self.ran_lib


### PR DESCRIPTION
---

## Status

**READY**

## Description

get_instances always raised TypeError because the type check
validated the builtin id instead of the target_class argument,
and it delegated to AtlasExplorer.get_instances which does not
exist. Route it through AtlasExplorer.get_all instead, which
already handles taxonomy filtering. Add tests.

Closes: IBM/ai-atlas-nexus#211

Signed-off-by: Janam Patel <janamapatel@gmail.com>

## Impacted Areas in Application

- `AIAtlasNexus.get_instances()` in `src/ai_atlas_nexus/library.py`
- tests in `tests/ai_atlas_nexus/test_library.py`

### Screenshots

Not applicable (python library change, no UI).

## Which issue(s) does this pull-request fix?

https://github.com/IBM/ai-atlas-nexus/issues/211

Closes: IBM/ai-atlas-nexus#211

## Any special notes for your reviewer?

The method could never return before this change (the broken type
check fired on every call), so no existing caller can depend on the
old behavior.

---

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided
