### PR TITLE
fix: restore name lookup in get_related_risks

### DIFF
--- a/src/ai_atlas_nexus/library.py
+++ b/src/ai_atlas_nexus/library.py
@@ -415,6 +415,8 @@ class AIAtlasNexus:
             risk = cls.get_risk(id=id)
         elif tag:
             risk = cls.get_risk(tag=tag)
+        elif name:
+            risk = cls.get_risk(name=name)
 
         # just get all the related risks from the risk, these should have been added during lifting
         options = [

--- a/tests/ai_atlas_nexus/test_library.py
+++ b/tests/ai_atlas_nexus/test_library.py
@@ -131,6 +131,14 @@ class TestLibrary(TestCaseBase):
         risks = ran_lib.get_related_risks(id="granite-function-call")
         self.assertGreater(len(risks), 0)
 
+    def test_get_related_risks_by_name(self):
+        """Get related risk definitions from the LinkML, by risk name"""
+        ran_lib = self.ran_lib
+        risks = ran_lib.get_related_risks(name="Toxic output")
+        self.assertGreater(len(risks), 0)
+        risks_by_id = ran_lib.get_related_risks(id="atlas-toxic-output")
+        assert [i.id for i in risks] == [i.id for i in risks_by_id]
+
     def test_get_risk_actions_by_risk_id(self):
         """Get related actions definitions from the LinkML, by risk id"""
         ran_lib = self.ran_lib


### PR DESCRIPTION
## Status

**READY**

## Description

get_related_risks documents lookup by id, tag, or name and its input validation accepts name alone, but the resolution block
only handled id and tag, so a name-only call crashed with AttributeError on a None risk. Add the missing name branch, mirroring get_related_actions. Add a regression test.

Closes: IBM/ai-atlas-nexus#218

Signed-off-by: Janam Patel <janamapatel@gmail.com>

## Impacted Areas in Application

- `AIAtlasNexus.get_related_risks()` in `src/ai_atlas_nexus/library.py`
- tests in `tests/ai_atlas_nexus/test_library.py`

### Screenshots

Not applicable (python library change, no UI).

## Which issue(s) does this pull-request fix?

Closes: IBM/ai-atlas-nexus#218

## Any special notes for your reviewer?

Only the name-only lookup path change: callers passing risk, id, or tag take exactly the same code path as before. This is complementary to PR #217 (which fixes the taxonomy handling of the same method for #215). But that PR doesn't touch the id/tag/name lookup block, so the two changes are independent.

Note: running test_library.py as a whole currently fails several pre-existing get_related_risks tests on main as well, that is an
explorer cache issue reported separately in #219, not related to this change. The tests here pass with
`pytest tests/ai_atlas_nexus/test_library.py -k related_risk`.

---

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided