### PR TITLE
fix: distinguish taxonomy=None in get_all cache key

### DIFF
--- a/src/ai_atlas_nexus/blocks/graph_explorer/atlas.py
+++ b/src/ai_atlas_nexus/blocks/graph_explorer/atlas.py
@@ -88,11 +88,9 @@ class AtlasExplorer(ExplorerBase):
 
         taxonomies = []
 
-        if taxonomy is None:
-            taxonomies = ["ibm-risk-atlas"]
-        elif isinstance(taxonomy, str):
+        if isinstance(taxonomy, str):
             taxonomies.append(taxonomy)
-        else:
+        elif taxonomy is not None:
             taxonomies = taxonomy
 
         cache_key = (
@@ -101,7 +99,7 @@ class AtlasExplorer(ExplorerBase):
                 if isinstance(class_names, list)
                 else class_name
             ),
-            tuple(taxonomies),
+            tuple(taxonomies) if taxonomy is not None else None,
             vocabulary,
             document,
         )

--- a/tests/ai_atlas_nexus/test_library.py
+++ b/tests/ai_atlas_nexus/test_library.py
@@ -424,6 +424,22 @@ class TestLibrary(TestCaseBase):
         # Cache should have two entries for these different queries
         self.assertEqual(len(ran_lib._atlas_explorer._combined_cache), 2)
 
+    def test_get_all_cache_taxonomy_none_distinct(self):
+        """Verify unfiltered and taxonomy-filtered get_all do not share a cache entry"""
+        ran_lib = self.ran_lib
+        # filtered first, then unfiltered
+        ran_lib._atlas_explorer.clear_cache()
+        filtered = ran_lib.get_all("risks", taxonomy="ibm-risk-atlas")
+        all_risks = ran_lib.get_all("risks")
+        self.assertGreater(len(all_risks), len(filtered))
+        self.assertEqual(len(ran_lib._atlas_explorer._combined_cache), 2)
+        # reverse order on a cold cache: filtered call must not get the unfiltered entry
+        ran_lib._atlas_explorer.clear_cache()
+        all_risks_2 = ran_lib.get_all("risks")
+        filtered_2 = ran_lib.get_all("risks", taxonomy="ibm-risk-atlas")
+        self.assertEqual(len(all_risks_2), len(all_risks))
+        self.assertEqual(len(filtered_2), len(filtered))
+
     def test_clear_cache_invalidates_all_caches(self):
         """Verify that clear_cache() invalidates both caches"""
         ran_lib = self.ran_lib


### PR DESCRIPTION
## Status

**READY**

## Description

AtlasExplorer.get_all built its cache key from a taxonomies list
that defaulted to ["ibm-risk-atlas"] when taxonomy was None, while
the taxonomy filter only ran for a non-None taxonomy. An unfiltered
call and a taxonomy="ibm-risk-atlas" call therefore shared one cache
entry with different expected results, and whichever ran first won.
Per the discussion in #219, taxonomy=None means "all taxonomies":
remove the unused default and keep None in the cache key so
unfiltered and filtered calls cache separately. Add a regression
test covering both call orders.

Closes: IBM/ai-atlas-nexus#219

Signed-off-by: Janam Patel <janamapatel@gmail.com>

## Impacted Areas in Application

- `AtlasExplorer.get_all()` in `src/ai_atlas_nexus/blocks/graph_explorer/atlas.py`
- tests in `tests/ai_atlas_nexus/test_library.py`

### Screenshots

Not applicable (python library change, no UI).

## Which issue(s) does this pull-request fix?

Closes: IBM/ai-atlas-nexus#219

## Any special notes for your reviewer?

No behaviour change for any individual call. Filtered calls filter
exactly as before and unfiltered calls return everything, as decided
in #219; only the cache separation is new. The collision was broken
in both directions on main (a filtered call after an unfiltered one
was served the unfiltered superset too), so the regression test
covers both call orders. The test asserts relationships rather than
hardcoded counts, so it stays valid as taxonomies and risks are
added. With this fix the whole of test_library.py passes again when
run as one file (48 passed; on current main the same run has 4
order-dependent failures caused by the shared cache), and the full
test suite passes (166 passed).

---

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided