### PR TITLE
feat: classify SKOS relation in RiskMapper inference method

### DIFF
--- a/src/ai_atlas_nexus/blocks/risk_detector/__init__.py
+++ b/src/ai_atlas_nexus/blocks/risk_detector/__init__.py
@@ -1,3 +1,4 @@
 from .base import RiskDetector
 from .benchmarks import BenchmarkRiskDetector
 from .generic import GenericRiskDetector
+from .relations import RiskRelationDetector

--- a/src/ai_atlas_nexus/blocks/risk_detector/relations.py
+++ b/src/ai_atlas_nexus/blocks/risk_detector/relations.py
@@ -1,0 +1,141 @@
+import copy
+import json
+from typing import List, NamedTuple
+
+from ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
+from ai_atlas_nexus.blocks.inference import TextGenerationInferenceOutput
+from ai_atlas_nexus.blocks.risk_detector import RiskDetector
+from ai_atlas_nexus.toolkit.logging import configure_logger
+
+
+logger = configure_logger(__name__)
+
+
+class RiskRelation(NamedTuple):
+    """A candidate risk and its SKOS mapping predicate to the source risk."""
+
+    risk: Risk
+    predicate: str
+
+
+# The SKOS predicates used for cross-taxonomy mappings, strongest first. The
+# directional broad/narrow predicates are intentionally excluded here: they are
+# used for matches within a single taxonomy, whereas the risk mapper produces
+# cross-taxonomy mappings.
+RELATION_PREDICATES = {
+    "exactMatch": "skos:exactMatch",
+    "closeMatch": "skos:closeMatch",
+    "relatedMatch": "skos:relatedMatch",
+}
+
+
+# Relation-classification template. Given a source risk and a set of candidate
+# risks from other taxonomies, the model returns the SKOS relation for each
+# candidate that is genuinely related, and omits the rest.
+RISK_RELATION_IDENTIFICATION_TEMPLATE = """You are an expert at mapping AI risks across different risk taxonomies.
+
+You are given a source risk and a list of candidate risks from other taxonomies. For each candidate that is genuinely related to the source risk, classify the relationship using one of these SKOS mapping predicates:
+
+- exactMatch: the two risks describe the same risk and can be used interchangeably.
+- closeMatch: the two risks are very similar and can be used interchangeably in many, but not all, applications.
+- relatedMatch: the two risks are associated or overlap, but are not close enough to substitute for one another.
+
+Only include candidates that are at least a relatedMatch. Omit any candidate that is unrelated to the source risk.
+
+CANDIDATE RISKS:
+{{ risks }}
+
+{% if cot_examples is not none and cot_examples|length > 0 %}
+EXAMPLES:
+{% for example in cot_examples %}
+Source risk: {{ example.Usecase }}
+Reasoning: {{ example.Reasoning }}
+Risks: {{ example.Risks }}
+{% endfor %}
+===== END OF EXAMPLES ======
+{% endif %}
+Now classify the relationship between the following source risk and the candidate risks. Think step by step.
+
+Source risk: {{ usecase }}
+
+Respond with a JSON array of objects, each having 'category' (the candidate risk name, exactly as listed) and 'relation' (one of exactMatch, closeMatch, relatedMatch). Include only related candidates.
+JSON: """
+
+
+# Array-of-objects response schema. The candidate names are populated per call.
+RISK_RELATION_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "enum": None},
+            "relation": {
+                "type": "string",
+                "enum": list(RELATION_PREDICATES.keys()),
+            },
+        },
+        "required": ["category", "relation"],
+    },
+}
+
+
+class RiskRelationDetector(RiskDetector):
+    """Classify the SKOS relation between a source risk and candidate risks.
+
+    Unlike the other detectors, ``detect`` returns, for each source risk, a
+    list of :class:`RiskRelation` (candidate risk + SKOS predicate) rather than
+    a bare list of risks, so the risk mapper can emit a graded ``predicate_id``
+    instead of a single hardcoded value.
+    """
+
+    def detect(self, usecases: List[str]) -> List[List[RiskRelation]]:
+        prompts = [
+            self.prompt_builder(
+                prompt_template=RISK_RELATION_IDENTIFICATION_TEMPLATE
+            ).build(
+                cot_examples=self._examples,
+                usecase=usecase,
+                risks=json.dumps(
+                    [
+                        {"category": risk.name, "description": risk.description}
+                        for risk in self._risks
+                    ],
+                    indent=4,
+                ),
+            )
+            for usecase in usecases
+        ]
+
+        json_schema = copy.deepcopy(RISK_RELATION_SCHEMA)
+        json_schema["items"]["properties"]["category"]["enum"] = [
+            risk.name for risk in self._risks
+        ]
+
+        inference_responses: List[TextGenerationInferenceOutput] = (
+            self.inference_engine.generate(
+                prompts,
+                response_format=json_schema,
+                postprocessors=["json_object"],
+            )
+        )
+
+        risks_by_name = {risk.name: risk for risk in self._risks}
+        results: List[List[RiskRelation]] = []
+        for response in inference_responses:
+            prediction = response.prediction
+            relations: List[RiskRelation] = []
+            if isinstance(prediction, list):
+                for item in prediction:
+                    if not isinstance(item, dict):
+                        continue
+                    name = item.get("category")
+                    relation = item.get("relation")
+                    if name in risks_by_name and relation in RELATION_PREDICATES:
+                        relations.append(
+                            RiskRelation(
+                                risks_by_name[name], RELATION_PREDICATES[relation]
+                            )
+                        )
+            results.append(relations)
+
+        return results

--- a/src/ai_atlas_nexus/blocks/risk_mapping/risk_mapper.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/risk_mapper.py
@@ -1,17 +1,12 @@
 import datetime
-import json
 import re
-from typing import List
 
 from sssom_schema import EntityReference, Mapping
 from txtai import Embeddings
 
 from ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
 from ai_atlas_nexus.blocks.inference import InferenceEngine
-from ai_atlas_nexus.blocks.inference.params import TextGenerationInferenceOutput
-from ai_atlas_nexus.blocks.prompt_builder import ZeroShotPromptBuilder
-from ai_atlas_nexus.blocks.prompt_response_schema import LIST_OF_STR_SCHEMA
-from ai_atlas_nexus.blocks.risk_detector import GenericRiskDetector
+from ai_atlas_nexus.blocks.risk_detector import RiskRelationDetector
 from ai_atlas_nexus.blocks.risk_mapping import RiskMappingBase
 from ai_atlas_nexus.metadata_base import MappingMethod
 from ai_atlas_nexus.toolkit.logging import configure_logger
@@ -174,25 +169,22 @@ class RiskMapper(RiskMappingBase):
                 for nr in new_risks
             ]
 
-            risk_detector = GenericRiskDetector(
+            relation_detector = RiskRelationDetector(
                 risks=existing_risks,
                 inference_engine=self.inference_engine,
                 cot_examples=None,
             )
 
-            rls = risk_detector.detect(usecases)
+            rls = relation_detector.detect(usecases)
 
-            for (
-                index,
-                rl,
-            ) in enumerate(rls):
-                for risk in rl:
+            for index, matches in enumerate(rls):
+                for risk, predicate in matches:
                     mapping = Mapping(
                         subject_id=self._format_with_curie(
                             new_risks[index].isDefinedByTaxonomy, new_risks[index].id
                         ),
                         subject_label=new_risks[index].name,
-                        predicate_id="skos:relatedMatch",  #  opted for this here as there is no way to assess relatedness of match with current template
+                        predicate_id=predicate,
                         object_id=self._format_with_curie(
                             taxonomy_for_mapping[risk.id.strip()], risk.id
                         ),

--- a/tests/ai_atlas_nexus/blocks/risk_detector/test_relations.py
+++ b/tests/ai_atlas_nexus/blocks/risk_detector/test_relations.py
@@ -1,0 +1,227 @@
+"""Tests for RiskRelationDetector (RiskMapper INFERENCE relation classification).
+
+Two engine stubs are used, both deterministic and CI-safe:
+
+* ``_FakeEngine`` returns already-parsed predictions, to exercise the detector's
+  parsing/filtering logic in isolation.
+* ``_RawEngine`` returns raw model strings and runs them through the real
+  ``json_object`` postprocessor, to exercise the full model-output -> parse
+  chain the way a real inference engine (Ollama, vLLM, WML, ...) would.
+"""
+
+from types import SimpleNamespace
+
+from ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
+from ai_atlas_nexus.blocks.inference.postprocessing import POSTPROCESSORS_REGISTRY
+from ai_atlas_nexus.blocks.risk_detector import RiskRelationDetector
+
+
+def _risk(rid, name, description, taxonomy="tax-existing"):
+    return Risk(
+        id=rid, name=name, description=description, isDefinedByTaxonomy=taxonomy
+    )
+
+
+class _FakeEngine:
+    """Engine stub returning already-postprocessed predictions."""
+
+    def __init__(self, predictions):
+        self._predictions = predictions
+        self.captured = {}
+
+    def generate(self, prompts, response_format=None, postprocessors=None):
+        self.captured = {
+            "prompts": prompts,
+            "response_format": response_format,
+            "postprocessors": postprocessors,
+        }
+        return [
+            SimpleNamespace(prediction=pred)
+            for pred in self._predictions[: len(prompts)]
+        ]
+
+
+class _RawEngine:
+    """Engine stub returning raw model strings, run through real postprocessors.
+
+    This mirrors what a real InferenceEngine does: the model emits text, and the
+    registered postprocessors turn it into a Python object before the detector
+    parses it. It keeps the test deterministic while covering the real chain.
+    """
+
+    def __init__(self, raw_outputs):
+        self._raw = raw_outputs
+
+    def generate(self, prompts, response_format=None, postprocessors=None):
+        outputs = []
+        for raw in self._raw[: len(prompts)]:
+            prediction = raw
+            for processor in postprocessors or []:
+                prediction = POSTPROCESSORS_REGISTRY[processor]().apply(prediction)
+            outputs.append(SimpleNamespace(prediction=prediction))
+        return outputs
+
+
+def _detector(engine, risks):
+    return RiskRelationDetector(risks=risks, inference_engine=engine, cot_examples=None)
+
+
+CANDIDATES = [
+    _risk("atlas-a", "Alpha risk", "About alpha"),
+    _risk("atlas-b", "Beta risk", "About beta"),
+]
+
+
+class TestParsing:
+    """Detector parsing/filtering logic (predictions already postprocessed)."""
+
+    def test_maps_relation_labels_to_skos_predicates(self):
+        engine = _FakeEngine([[{"category": "Beta risk", "relation": "closeMatch"}]])
+        result = _detector(engine, CANDIDATES).detect(["a new risk"])
+        assert len(result) == 1 and len(result[0]) == 1
+        risk, predicate = result[0][0]
+        assert risk.id == "atlas-b"
+        assert predicate == "skos:closeMatch"
+
+    def test_named_tuple_fields(self):
+        engine = _FakeEngine([[{"category": "Alpha risk", "relation": "exactMatch"}]])
+        rel = _detector(engine, CANDIDATES).detect(["x"])[0][0]
+        assert rel.risk.id == "atlas-a"
+        assert rel.predicate == "skos:exactMatch"
+
+    def test_schema_enumerates_candidate_names_and_relations(self):
+        engine = _FakeEngine([[]])
+        _detector(engine, CANDIDATES).detect(["a new risk"])
+        schema = engine.captured["response_format"]
+        assert schema["items"]["properties"]["category"]["enum"] == [
+            "Alpha risk",
+            "Beta risk",
+        ]
+        assert schema["items"]["properties"]["relation"]["enum"] == [
+            "exactMatch",
+            "closeMatch",
+            "relatedMatch",
+        ]
+        assert engine.captured["postprocessors"] == ["json_object"]
+
+    def test_omits_unknown_names_and_invalid_relations(self):
+        engine = _FakeEngine(
+            [
+                [
+                    {"category": "Beta risk", "relation": "exactMatch"},
+                    {"category": "Ghost risk", "relation": "closeMatch"},  # unknown
+                    {"category": "Alpha risk", "relation": "broadMatch"},  # excluded
+                    {"category": "Alpha risk", "relation": "noMatch"},  # not a match
+                ]
+            ]
+        )
+        result = _detector(engine, CANDIDATES).detect(["a new risk"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-b", "skos:exactMatch")]
+
+    def test_relation_label_is_case_sensitive(self):
+        engine = _FakeEngine([[{"category": "Alpha risk", "relation": "ExactMatch"}]])
+        assert _detector(engine, CANDIDATES).detect(["x"]) == [[]]
+
+    def test_item_missing_keys_is_skipped(self):
+        engine = _FakeEngine(
+            [
+                [
+                    {"category": "Alpha risk"},  # no relation
+                    {"relation": "exactMatch"},  # no category
+                    {"category": "Beta risk", "relation": "relatedMatch"},
+                ]
+            ]
+        )
+        result = _detector(engine, CANDIDATES).detect(["x"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-b", "skos:relatedMatch")]
+
+    def test_non_list_prediction_yields_no_pairs(self):
+        engine = _FakeEngine(["not json"])
+        assert _detector(engine, CANDIDATES).detect(["a new risk"]) == [[]]
+
+    def test_multiple_usecases_return_aligned_results(self):
+        engine = _FakeEngine(
+            [
+                [{"category": "Alpha risk", "relation": "relatedMatch"}],
+                [{"category": "Beta risk", "relation": "exactMatch"}],
+            ]
+        )
+        result = _detector(engine, CANDIDATES).detect(["risk one", "risk two"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-a", "skos:relatedMatch")]
+        assert [(r.id, p) for r, p in result[1]] == [("atlas-b", "skos:exactMatch")]
+
+
+class TestRealPostprocessorChain:
+    """Full raw-string -> json_object postprocessor -> parse chain."""
+
+    def test_clean_json_array(self):
+        engine = _RawEngine(['[{"category": "Beta risk", "relation": "closeMatch"}]'])
+        result = _detector(engine, CANDIDATES).detect(["x"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-b", "skos:closeMatch")]
+
+    def test_surrounding_whitespace_and_newlines(self):
+        engine = _RawEngine(
+            ['\n\n  [{"category": "Alpha risk", "relation": "exactMatch"}]  \n']
+        )
+        result = _detector(engine, CANDIDATES).detect(["x"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-a", "skos:exactMatch")]
+
+    def test_backtick_fenced_json(self):
+        engine = _RawEngine(
+            ['```\n[{"category": "Beta risk", "relation": "relatedMatch"}]\n```']
+        )
+        result = _detector(engine, CANDIDATES).detect(["x"])
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-b", "skos:relatedMatch")]
+
+    def test_malformed_model_output_is_handled_gracefully(self):
+        engine = _RawEngine(["Sure! Here are the matches: none really."])
+        assert _detector(engine, CANDIDATES).detect(["x"]) == [[]]
+
+    def test_empty_json_array(self):
+        engine = _RawEngine(["[]"])
+        assert _detector(engine, CANDIDATES).detect(["x"]) == [[]]
+
+
+class TestEdgeCases:
+
+    def test_no_candidates(self):
+        engine = _FakeEngine([[]])
+        detector = _detector(engine, [])
+        result = detector.detect(["x"])
+        assert result == [[]]
+        assert (
+            engine.captured["response_format"]["items"]["properties"]["category"][
+                "enum"
+            ]
+            == []
+        )
+
+    def test_no_usecases(self):
+        engine = _FakeEngine([])
+        assert _detector(engine, CANDIDATES).detect([]) == []
+
+    def test_one_usecase_with_no_matches_among_many(self):
+        engine = _FakeEngine(
+            [
+                [],  # first source risk matches nothing
+                [{"category": "Alpha risk", "relation": "exactMatch"}],
+            ]
+        )
+        result = _detector(engine, CANDIDATES).detect(["r1", "r2"])
+        assert result[0] == []
+        assert [(r.id, p) for r, p in result[1]] == [("atlas-a", "skos:exactMatch")]
+
+    def test_many_candidates_schema_and_parse(self):
+        many = [_risk(f"atlas-{i}", f"Risk {i}", f"desc {i}") for i in range(50)]
+        engine = _FakeEngine([[{"category": "Risk 42", "relation": "closeMatch"}]])
+        detector = _detector(engine, many)
+        result = detector.detect(["x"])
+        assert (
+            len(
+                engine.captured["response_format"]["items"]["properties"]["category"][
+                    "enum"
+                ]
+            )
+            == 50
+        )
+        assert [(r.id, p) for r, p in result[0]] == [("atlas-42", "skos:closeMatch")]

--- a/tests/ai_atlas_nexus/blocks/risk_mapping/test_risk_mapper.py
+++ b/tests/ai_atlas_nexus/blocks/risk_mapping/test_risk_mapper.py
@@ -1,5 +1,6 @@
-"""Tests for RiskMapper semantic mapping."""
+"""Tests for RiskMapper semantic and inference mapping."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -75,6 +76,54 @@ class TestGenerateSemanticBelowThreshold:
 
         assert mappings == []
         assert "No match found for new-x" in caplog.text
+
+
+class _FakeEngine:
+    """Inference engine stub returning canned, already-postprocessed predictions."""
+
+    def __init__(self, predictions):
+        self._predictions = predictions
+
+    def generate(self, prompts, response_format=None, postprocessors=None):
+        return [
+            SimpleNamespace(prediction=pred)
+            for pred in self._predictions[: len(prompts)]
+        ]
+
+
+class TestGenerateInference:
+    """generate() with INFERENCE emits the graded predicate from the classifier."""
+
+    def test_inference_uses_graded_predicate(self):
+        existing = [
+            _risk("atlas-a", "Alpha risk", "About alpha", "tax-existing"),
+            _risk("atlas-b", "Beta risk", "About beta", "tax-existing"),
+        ]
+        new = [_risk("new-b", "Beta-ish risk", "About beta", "tax-new")]
+        engine = _FakeEngine([[{"category": "Beta risk", "relation": "closeMatch"}]])
+        mapper = RiskMapper(
+            new_risks=new,
+            existing_risks=existing,
+            inference_engine=engine,
+            new_prefix="tax-new",
+            mapping_method=MappingMethod.INFERENCE,
+        )
+
+        mappings = mapper.generate(
+            new_risks=new,
+            existing_risks=existing,
+            inference_engine=engine,
+            new_prefix="tax-new",
+            mapping_method=MappingMethod.INFERENCE,
+        )
+
+        assert len(mappings) == 1
+        m = mappings[0]
+        assert m.subject_id == "tax-new:new-b"
+        assert m.object_id == "tax-existing:atlas-b"
+        # graded, not the old hardcoded skos:relatedMatch
+        assert m.predicate_id == "skos:closeMatch"
+        assert m.mapping_justification == "semapv:LLMBasedMatching"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Status

**READY**

## Description

The risk mapper's `MappingMethod.INFERENCE` path hardcoded
`skos:relatedMatch` for every mapping, because the detector it used
(`GenericRiskDetector`) only answers a binary "is this risk present?
Yes/No" and gives no measure of how strong the match is.

Add a `RiskRelationDetector` (a custom `RiskDetector`, following the
`benchmarks.py` pattern) that classifies the SKOS relation between a
source risk and each candidate risk in a single pass, and have the
mapper emit that graded `predicate_id` instead of the hardcoded value.

Per the discussion on #231:
- Vocabulary is `exactMatch` / `closeMatch` / `relatedMatch`. The
  directional `broadMatch` / `narrowMatch` are intentionally excluded:
  they apply to matches within one taxonomy, whereas the mapper
  produces cross-taxonomy mappings.
- It is a single classification pass, with no separate presence
  pre-filter. The prefilter can be revisited later.

Closes: IBM/ai-atlas-nexus#231

Signed-off-by: Janam Patel <janamapatel@gmail.com>

## Impacted Areas in Application

- new `RiskRelationDetector` in `src/ai_atlas_nexus/blocks/risk_detector/relations.py`
- `RiskMapper` INFERENCE branch in `src/ai_atlas_nexus/blocks/risk_mapping/risk_mapper.py`
- new tests in `tests/ai_atlas_nexus/blocks/risk_detector/test_relations.py`
- INFERENCE test added to `tests/ai_atlas_nexus/blocks/risk_mapping/test_risk_mapper.py`

### Screenshots

Not applicable (python library change, no UI).

## Which issue(s) does this pull-request fix?

Closes: IBM/ai-atlas-nexus#231

## Any special notes for your reviewer?

Engine-agnostic: the detector calls the standard
`InferenceEngine.generate(response_format=..., postprocessors=...)`
interface, so it works unchanged across Ollama, vLLM, WML, RITS and
HF. I validated it end to end on Ollama with `granite4.1:3b`. Mapping
5 NIST AI RMF risks onto 40 IBM Risk Atlas risks produced 12 proposed
mappings: 2 `skos:exactMatch` ("Confabulation" -> "Hallucination" and
"Environmental Impacts" -> "Impact on the environment") and 10
`skos:relatedMatch`. Previously all 12 would have been labelled
`skos:relatedMatch`, so the two genuine equivalences are now
distinguished.

Model output is constrained with an array-of-objects `response_format`
whose `category` enum is the candidate risk names and `relation` enum
is the three predicates, so the model cannot invent names or labels.
Parsing is also defensive: malformed or non-JSON output yields no
mappings for that risk rather than an error.

Tests are deterministic and need no live LLM. One stub returns
already-parsed predictions (parsing/filtering logic); another returns
raw model strings run through the real `json_object` postprocessor
(the full output-to-parse chain), covering clean JSON, surrounding
whitespace, backtick-fenced JSON, malformed output, empty results,
no candidates, no source risks, and a larger candidate set. Full
suite passes. I also removed a few unused imports in `risk_mapper.py` that were
left over in the file being changed.

---

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided