### PR TITLE
feat(catalogs): model/test external references as documentation slots

### DIFF
--- a/src/ai_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/ai_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -375,7 +375,7 @@ class Documentation(Entity):
     """
     Documented information about a concept or other topic(s) of interest.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['ExternalReference', 'see also'],
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['ExternalReference'],
          'class_uri': 'airo:Documentation',
          'from_schema': 'https://w3id.org/ai-atlas-nexus/common',
          'slot_usage': {'isCategorizedAs': {'description': 'The category this document '
@@ -704,9 +704,9 @@ class Control(Entity):
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["Control"] = Field(default="Control", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
@@ -886,9 +886,9 @@ class Entry(Entity):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -1002,9 +1002,9 @@ class Term(Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -1107,9 +1107,9 @@ class Principle(Entry):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -1767,9 +1767,9 @@ class Certification(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -1851,9 +1851,9 @@ class LocalityOfUse(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -2448,9 +2448,9 @@ class Risk(RiskConcept, Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     requiredByTask: Optional[list[Any]] = Field(default=None, description="""Indicates that this entry is required to perform a specific AI task.""", json_schema_extra = { "linkml_meta": {'domain': 'Entry',
          'domain_of': ['Entry', 'Capability'],
@@ -2544,9 +2544,9 @@ class RiskControl(RiskConcept, Control):
     isUsedWithinLocality: Optional[list[str]] = Field(default=None, description="""Specifies the domain an AI system is used within.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RiskConcept', 'AiSystem'],
          'slot_uri': 'airo:isUsedWithinLocality'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["RiskControl"] = Field(default="RiskControl", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
@@ -2680,9 +2680,9 @@ class Action(RiskControl):
     isUsedWithinLocality: Optional[list[str]] = Field(default=None, description="""Specifies the domain an AI system is used within.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RiskConcept', 'AiSystem'],
          'slot_uri': 'airo:isUsedWithinLocality'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["Action"] = Field(default="Action", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
@@ -3544,9 +3544,9 @@ class Capability(CapabilityConcept, Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where a capability is part of a capability group""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -3757,9 +3757,9 @@ class AiSystem(BaseAi, Entry):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -3909,9 +3909,9 @@ class AiAgent(AiSystem):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -4060,9 +4060,9 @@ class AiTask(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -4568,9 +4568,9 @@ class Purpose(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -4673,9 +4673,9 @@ class Domain(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
@@ -5972,9 +5972,9 @@ class Adapter(LargeLanguageModel, Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     requiredByTask: Optional[list[Any]] = Field(default=None, description="""Indicates that this entry is required to perform a specific AI task.""", json_schema_extra = { "linkml_meta": {'domain': 'Entry',
          'domain_of': ['Entry', 'Capability'],
@@ -6105,9 +6105,9 @@ class LLMIntrinsic(Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
-    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['additional resources', 'external_links'],
+         'close_mappings': ['rdfs:seeAlso'],
          'domain_of': ['Control', 'Entry'],
-         'exact_mappings': ['rdfs:seeAlso'],
          'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',

--- a/src/ai_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
+++ b/src/ai_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py
@@ -2,10 +2,20 @@ from __future__ import annotations
 
 import re
 import sys
-from datetime import date, datetime, time
+from datetime import (
+    date,
+    datetime,
+    time
+)
 from decimal import Decimal
 from enum import Enum
-from typing import Any, ClassVar, Literal, Optional, Union
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    Union
+)
 
 from pydantic import (
     BaseModel,
@@ -15,11 +25,11 @@ from pydantic import (
     SerializationInfo,
     SerializerFunctionWrapHandler,
     field_validator,
-    model_serializer,
+    model_serializer
 )
 
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 version = "0.5.0"
 
 
@@ -365,8 +375,17 @@ class Documentation(Entity):
     """
     Documented information about a concept or other topic(s) of interest.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'airo:Documentation',
-         'from_schema': 'https://w3id.org/ai-atlas-nexus/common'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['ExternalReference', 'see also'],
+         'class_uri': 'airo:Documentation',
+         'from_schema': 'https://w3id.org/ai-atlas-nexus/common',
+         'slot_usage': {'isCategorizedAs': {'description': 'The category this document '
+                                                           'falls under, referenced as '
+                                                           'a catalogued Term rather '
+                                                           'than repeated as free '
+                                                           'text, so grouping labels '
+                                                           'are declared in one place.',
+                                            'name': 'isCategorizedAs',
+                                            'range': 'Term'}}})
 
     hasLicense: Optional[str] = Field(default=None, description="""Indicates licenses associated with a resource""", json_schema_extra = { "linkml_meta": {'domain_of': ['Dataset',
                        'Documentation',
@@ -392,7 +411,7 @@ class Documentation(Entity):
     related_mappings: Optional[list[Any]] = Field(default=None, description="""The property skos:relatedMatch is used to state an associative mapping link between two concepts.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entity'], 'slot_uri': 'skos:relatedMatch'} })
     narrow_mappings: Optional[list[Any]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a narrower concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entity'], 'slot_uri': 'skos:narrowMatch'} })
     broad_mappings: Optional[list[Any]] = Field(default=None, description="""The property is used to state a hierarchical mapping link between two concepts, indicating that the concept linked to, is a broader concept than the originating concept.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entity'], 'slot_uri': 'skos:broadMatch'} })
-    isCategorizedAs: Optional[list[Any]] = Field(default=None, description="""A relationship where an entity has been deemed to be categorized""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entity'], 'slot_uri': 'nexus:isCategorizedAs'} })
+    isCategorizedAs: Optional[list[str]] = Field(default=None, description="""The category this document falls under, referenced as a catalogued Term rather than repeated as free text, so grouping labels are declared in one place.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entity'], 'slot_uri': 'nexus:isCategorizedAs'} })
 
 
 class Fact(ConfiguredBaseModel):
@@ -685,6 +704,10 @@ class Control(Entity):
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["Control"] = Field(default="Control", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
                        'Taxonomy',
@@ -863,6 +886,10 @@ class Entry(Entity):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -975,6 +1002,10 @@ class Term(Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -1076,6 +1107,10 @@ class Principle(Entry):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -1732,6 +1767,10 @@ class Certification(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -1812,6 +1851,10 @@ class LocalityOfUse(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -2405,6 +2448,10 @@ class Risk(RiskConcept, Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     requiredByTask: Optional[list[Any]] = Field(default=None, description="""Indicates that this entry is required to perform a specific AI task.""", json_schema_extra = { "linkml_meta": {'domain': 'Entry',
          'domain_of': ['Entry', 'Capability'],
          'inverse': 'requiresCapability'} })
@@ -2497,6 +2544,10 @@ class RiskControl(RiskConcept, Control):
     isUsedWithinLocality: Optional[list[str]] = Field(default=None, description="""Specifies the domain an AI system is used within.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RiskConcept', 'AiSystem'],
          'slot_uri': 'airo:isUsedWithinLocality'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["RiskControl"] = Field(default="RiskControl", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
                        'Taxonomy',
@@ -2629,6 +2680,10 @@ class Action(RiskControl):
     isUsedWithinLocality: Optional[list[str]] = Field(default=None, description="""Specifies the domain an AI system is used within.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RiskConcept', 'AiSystem'],
          'slot_uri': 'airo:isUsedWithinLocality'} })
     isApplicableinLocality: Optional[list[str]] = Field(default=None, description="""A relationship where an entity has is applicable in these localities.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Control', 'Policy'], 'slot_uri': 'nexus:isApplicableinLocality'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     type: Literal["Action"] = Field(default="Action", description="""The type or class designation of this entity instance.""", json_schema_extra = { "linkml_meta": {'designates_type': True,
          'domain_of': ['Vocabulary',
                        'Taxonomy',
@@ -3489,6 +3544,10 @@ class Capability(CapabilityConcept, Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where a capability is part of a capability group""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -3698,6 +3757,10 @@ class AiSystem(BaseAi, Entry):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -3846,6 +3909,10 @@ class AiAgent(AiSystem):
          'slot_uri': 'schema:isPartOf'} })
     isDefinedByVocabulary: Optional[str] = Field(default=None, description="""A relationship where a term or a term group is defined by a vocabulary""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry', 'Term', 'Adapter', 'LLMIntrinsic'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -3993,6 +4060,10 @@ class AiTask(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -4497,6 +4568,10 @@ class Purpose(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -4598,6 +4673,10 @@ class Domain(Entry):
                        'Adapter',
                        'LLMIntrinsic'],
          'slot_uri': 'airo:hasDocumentation'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',
@@ -5893,6 +5972,10 @@ class Adapter(LargeLanguageModel, Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     requiredByTask: Optional[list[Any]] = Field(default=None, description="""Indicates that this entry is required to perform a specific AI task.""", json_schema_extra = { "linkml_meta": {'domain': 'Entry',
          'domain_of': ['Entry', 'Capability'],
          'inverse': 'requiresCapability'} })
@@ -6022,6 +6105,10 @@ class LLMIntrinsic(Entry):
                        'StakeholderGroup',
                        'Requirement'],
          'slot_uri': 'schema:isPartOf'} })
+    hasExternalReference: Optional[list[str]] = Field(default=None, description="""External references / additional resources related to this entity, such as articles, tools, or datasets. Distinct from hasDocumentation, which documents the entity itself. External references are not necessarily curated or vetted, and quality will vary.""", json_schema_extra = { "linkml_meta": {'aliases': ['see also', 'additional resource', 'related link'],
+         'domain_of': ['Control', 'Entry'],
+         'exact_mappings': ['rdfs:seeAlso'],
+         'slot_uri': 'nexus:hasExternalReference'} })
     isPartOf: Optional[str] = Field(default=None, description="""A relationship where an entity is part of another entity""", json_schema_extra = { "linkml_meta": {'domain_of': ['Entry',
                        'Risk',
                        'CapabilityGroup',

--- a/src/ai_atlas_nexus/ai_risk_ontology/schema/common.yaml
+++ b/src/ai_atlas_nexus/ai_risk_ontology/schema/common.yaml
@@ -403,7 +403,7 @@ slots:
     description: Indicates documentation associated with an entity.
   hasExternalReference:
     slot_uri: nexus:hasExternalReference
-    exact_mappings:
+    close_mappings:
       - rdfs:seeAlso
     aliases:
       - additional resources

--- a/src/ai_atlas_nexus/ai_risk_ontology/schema/common.yaml
+++ b/src/ai_atlas_nexus/ai_risk_ontology/schema/common.yaml
@@ -80,8 +80,16 @@ classes:
     is_a: Entity
     class_uri: airo:Documentation
     description: Documented information about a concept or other topic(s) of interest.
+    aliases:
+      - ExternalReference
     slots:
       - hasLicense
+    slot_usage:
+      isCategorizedAs:
+        range: Term
+        description: >-
+          The category this document falls under, referenced as a catalogued Term rather
+          than repeated as free text, so grouping labels are declared in one place.
     attributes:
       author:
         name: author
@@ -156,6 +164,7 @@ classes:
     slots:
       - isDefinedByTaxonomy
       - isApplicableinLocality
+      - hasExternalReference
 
   Group:
     is_a: Entity
@@ -197,6 +206,7 @@ classes:
       - isDefinedByTaxonomy
       - isDefinedByVocabulary
       - hasDocumentation
+      - hasExternalReference
       - isPartOf
       - requiredByTask
       - requiresCapability
@@ -391,6 +401,20 @@ slots:
     multivalued: true
     inlined: false
     description: Indicates documentation associated with an entity.
+  hasExternalReference:
+    slot_uri: nexus:hasExternalReference
+    exact_mappings:
+      - rdfs:seeAlso
+    aliases:
+      - additional resources
+      - external_links
+    range: Documentation
+    multivalued: true
+    inlined: false
+    description: >-
+      External references / additional resources related to this entity, such as articles,
+      tools, or datasets. Distinct from hasDocumentation, which documents the entity itself.
+      External references are not necessarily curated or vetted, and quality will vary.
   hasLicense:
     slot_uri: airo:hasLicense
     range: License

--- a/tests/ai_atlas_nexus/test_external_reference.py
+++ b/tests/ai_atlas_nexus/test_external_reference.py
@@ -1,0 +1,228 @@
+"""
+Tests for the `hasExternalReference` slot and the `Documentation.isCategorizedAs`
+narrowing added for https://github.com/IBM/ai-atlas-nexus/issues/181.
+
+The modelled shape is:
+
+    Entry/Control --hasExternalReference--> Documentation --isCategorizedAs--> Term
+
+Both edges are `inlined: false`, so they are id references and each document is
+declared exactly once in the Container however many records cite it.
+
+`hasExternalReference` is declared on `Entry` and on `Control` rather than on the
+root `Entity`: those two cover the catalogued domain concepts (risks, terms,
+principles, controls, actions) without giving `License`, `Organization` or
+`Dataset` a field they have no use for. The grouping label ("category") is a
+catalogued `Term` rather than a free string, so labels are declared in one place
+instead of being repeated as text in every record.
+
+The fixture is transcribed from the FINOS AI Governance Framework records that
+motivated the issue - risks ri-10 and ri-5, mitigation mi-3. Those two risks
+genuinely cite the same BBC report, which the source lists under three different
+titles; the fixture collapses it to one Documentation.
+"""
+
+# Standard
+import os
+from pathlib import Path
+
+# Third party
+import pytest
+from linkml_runtime import SchemaView
+from linkml_runtime.loaders import yaml_loader
+
+# Internal
+from src.ai_atlas_nexus.ai_risk_ontology.datamodel import ai_risk_ontology as datamodel
+from src.ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import (
+    Container,
+    Documentation,
+    Risk,
+)
+from tests.base import TestCaseBase
+
+SCHEMA_PATH = (
+    Path(datamodel.__file__).resolve().parents[1] / "schema" / "ai-risk-ontology.yaml"
+)
+
+
+class TestExternalReference(TestCaseBase):
+    """Tests for hasExternalReference and the Documentation.isCategorizedAs narrowing"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.schema_view = SchemaView(str(SCHEMA_PATH))
+        cls.container = yaml_loader.load_any(
+            source=os.path.join(cls.fixtures_dir, "external_reference_data.yaml"),
+            target_class=Container,
+        )
+        cls.entries = {entry.id: entry for entry in cls.container.entries}
+        cls.actions = {action.id: action for action in cls.container.actions}
+        cls.documents = {doc.id: doc for doc in cls.container.documents}
+
+    def _induced(self, class_name):
+        """Map of induced slot name -> slot definition for a class."""
+        return {
+            slot.name: slot for slot in self.schema_view.class_induced_slots(class_name)
+        }
+
+    ###############################################################################################
+    #                                    Schema contract                                          #
+    ###############################################################################################
+
+    def test_documentation_class_uri_is_preserved(self):
+        """issue #181 requires the airo:Documentation designation to survive the change"""
+        self.assertEqual(
+            self.schema_view.get_class("Documentation").class_uri, "airo:Documentation"
+        )
+
+    def test_documentation_aliases_include_external_reference(self):
+        """The alias requested by issue #181 makes the pattern discoverable"""
+        self.assertIn(
+            "ExternalReference", self.schema_view.get_class("Documentation").aliases
+        )
+
+    def test_has_external_reference_slot_contract(self):
+        """The slot points at Documentation by reference, not by inlining"""
+        slot = self.schema_view.get_slot("hasExternalReference")
+        self.assertEqual(slot.range, "Documentation")
+        self.assertTrue(slot.multivalued)
+        self.assertFalse(slot.inlined)
+        self.assertEqual(slot.slot_uri, "nexus:hasExternalReference")
+        self.assertIn("rdfs:seeAlso", slot.exact_mappings)
+
+    def test_has_external_reference_matches_has_documentation_inlining(self):
+        """Both point at Documentation by id so references live once and deduplicate"""
+        external = self.schema_view.get_slot("hasExternalReference")
+        documentation = self.schema_view.get_slot("hasDocumentation")
+        self.assertEqual(external.range, documentation.range)
+        self.assertEqual(bool(external.inlined), bool(documentation.inlined))
+
+    def test_has_external_reference_is_on_entry_and_control_not_entity(self):
+        """Scoped to catalogued concepts, so License/Organization/Documentation do not grow a field"""
+        # Entry side (FINOS risks) and Control side (FINOS mitigations).
+        for class_name in ("Term", "Risk", "Action", "RiskControl"):
+            self.assertIn(
+                "hasExternalReference",
+                self._induced(class_name),
+                f"{class_name} should carry hasExternalReference",
+            )
+        for class_name in ("Documentation", "License", "Organization", "Dataset"):
+            self.assertNotIn(
+                "hasExternalReference",
+                self._induced(class_name),
+                f"{class_name} should not carry hasExternalReference",
+            )
+
+    def test_documentation_is_categorized_as_narrowed_to_term(self):
+        """The grouping label is a catalogued Term rather than a free string"""
+        self.assertEqual(self._induced("Documentation")["isCategorizedAs"].range, "Term")
+
+    def test_is_categorized_as_narrowing_is_scoped_to_documentation(self):
+        """Narrowing must not leak onto the schema-level slot or other classes"""
+        self.assertEqual(self.schema_view.get_slot("isCategorizedAs").range, "Any")
+        self.assertEqual(self._induced("Risk")["isCategorizedAs"].range, "Any")
+
+    ###############################################################################################
+    #                                       Test data                                             #
+    ###############################################################################################
+
+    def test_all_external_references_resolve_to_declared_documents(self):
+        """Every referenced id must resolve to a Documentation declared in the Container"""
+        citing = list(self.entries.values()) + list(self.actions.values())
+        referenced = {
+            reference_id
+            for record in citing
+            for reference_id in (record.hasExternalReference or [])
+        }
+        self.assertTrue(referenced, "fixture should exercise hasExternalReference")
+        self.assertEqual(referenced - set(self.documents), set())
+
+    def test_finos_risk_carries_its_links(self):
+        """FINOS ri-10 "## Links" entries become hasExternalReference on a Risk"""
+        risk = self.entries["finos:ri-10"]
+        self.assertEqual(risk.name, "Prompt Injection")
+        self.assertIn("finos:doc-owasp-llm-top-10", risk.hasExternalReference)
+        self.assertEqual(
+            self.documents["finos:doc-bbc-dpd-chatbot"].url,
+            "https://www.bbc.co.uk/news/technology-68025677",
+        )
+
+    def test_finos_mitigation_carries_its_tooling_links(self):
+        """FINOS mi-3 is an Action, which reaches the slot through Control rather than Entry"""
+        action = self.actions["finos:mi-3"]
+        self.assertEqual(action.name, "User/App/Model Firewalling/Filtering")
+        self.assertEqual(
+            action.hasExternalReference,
+            [
+                "finos:doc-llm-guard",
+                "finos:doc-deberta-prompt-injection",
+                "finos:doc-shieldlm",
+            ],
+        )
+
+    def test_references_are_stored_once_and_cited_by_id(self):
+        """inlined: false means citing records hold ids, so a document is stored in one place"""
+        document_ids = [document.id for document in self.container.documents]
+        self.assertEqual(
+            len(document_ids), len(set(document_ids)), "documents must be unique"
+        )
+        for record in list(self.entries.values()) + list(self.actions.values()):
+            for reference in record.hasExternalReference or []:
+                self.assertIsInstance(
+                    reference, str, "references are ids, not embedded objects"
+                )
+
+    def test_shared_reference_is_declared_once_with_one_name(self):
+        """The BBC report is cited by ri-10 and ri-5; in FINOS it carries three
+        different titles, here it is one Documentation with one canonical name."""
+        citing = [
+            record.id
+            for record in list(self.entries.values()) + list(self.actions.values())
+            if "finos:doc-bbc-dpd-chatbot" in (record.hasExternalReference or [])
+        ]
+        self.assertEqual(sorted(citing), ["finos:ri-10", "finos:ri-5"])
+        self.assertEqual(
+            [doc.id for doc in self.container.documents].count(
+                "finos:doc-bbc-dpd-chatbot"
+            ),
+            1,
+        )
+
+    def test_categories_resolve_to_declared_terms(self):
+        """'Tooling' is an id reference to a catalogued Term, not a repeated string"""
+        category_ids = self.documents["finos:doc-llm-guard"].isCategorizedAs
+        self.assertEqual(category_ids, ["nexus:extref-category-tooling"])
+        self.assertEqual(self.entries[category_ids[0]].name, "Tooling")
+
+    def test_category_is_multivalued(self):
+        """One reference may carry several grouping labels"""
+        category_ids = self.documents["finos:doc-arxiv-jailbreaking-llms"].isCategorizedAs
+        self.assertEqual(
+            [self.entries[category_id].name for category_id in category_ids],
+            ["Links", "Tooling"],
+        )
+
+    def test_all_categories_resolve_to_declared_terms(self):
+        """No document may point at a category that was never declared"""
+        for document in self.container.documents:
+            for category_id in document.isCategorizedAs or []:
+                self.assertIn(category_id, self.entries)
+                self.assertEqual(self.entries[category_id].type, "Term")
+
+    ###############################################################################################
+    #                                     Negative cases                                          #
+    ###############################################################################################
+
+    def test_documentation_rejects_external_reference_slot(self):
+        """hasExternalReference hangs off Entry, so Documentation must reject it"""
+        with pytest.raises(ValueError):
+            Documentation(id="nexus:doc-x", hasExternalReference=["nexus:doc-y"])
+
+    def test_narrowed_range_rejects_inline_object(self):
+        """Documentation takes an id reference; Risk keeps the unnarrowed Any range"""
+        with pytest.raises(ValueError):
+            Documentation(id="nexus:doc-x", isCategorizedAs=[{"id": "nexus:term-y"}])
+
+        # The same value is still accepted where isCategorizedAs was not narrowed.
+        risk = Risk(id="nexus:risk-x", isCategorizedAs=[{"id": "nexus:term-y"}])
+        self.assertEqual(risk.isCategorizedAs, [{"id": "nexus:term-y"}])

--- a/tests/fixtures/external_reference_data.yaml
+++ b/tests/fixtures/external_reference_data.yaml
@@ -1,0 +1,147 @@
+# Test data for the hasExternalReference slot and the Documentation.isCategorizedAs
+# narrowing (range: Term). Container-shaped, loadable via
+# linkml_runtime.loaders.yaml_loader against the Container tree_root.
+#
+# Shape under test:
+#   Entry/Control --hasExternalReference--> Documentation --isCategorizedAs--> Term
+# Both edges are inlined: false, so they are id references and each document is
+# declared exactly once no matter how many records cite it.
+#
+# Content is taken from FINOS AI Governance Framework, which motivated
+#  https://github.com/IBM/ai-atlas-nexus/issues/181:
+#
+#  Links:
+#   docs/_risks/ri-10_prompt-injection.md
+#   docs/_risks/ri-5_foundation-model-versioning.md
+#
+#  Additional Resources ("Tooling" grouping):
+#   docs/_mitigations/mi-3_user-app-model-firewalling-filtering.md
+#
+# Those section names and the "Tooling" grouping bullet are what isCategorizedAs
+# captures here - the categories are transcribed, not invented.
+#
+# The finos: CURIE prefix (https://w3id.org/finos/aigf/) is used for downstream
+# record ids - "finos" is not declared in the schema (its consumer-side).
+
+vocabularies:
+  - id: nexus:vocab-external-reference-category
+    type: Vocabulary
+    name: External reference categories
+    description: Controlled grouping labels applied to external references.
+
+entries:
+  # Grouping labels, declared once and referenced by id. Both are taken from the
+  # section headings the FINOS documents actually use.
+  - id: nexus:extref-category-tooling
+    type: Term
+    name: Tooling
+    description: Software tools, libraries, and models.
+    isDefinedByVocabulary: nexus:vocab-external-reference-category
+
+  - id: nexus:extref-category-links
+    type: Term
+    name: Links
+    description: Background reading, incident reports, and research papers.
+    isDefinedByVocabulary: nexus:vocab-external-reference-category
+
+  # FINOS ri-10. A Risk is an Entry, so it carries hasExternalReference.
+  - id: finos:ri-10
+    type: Risk
+    name: Prompt Injection
+    url: https://air-governance-framework.finos.org/risks/ri-10_prompt-injection.html
+    hasExternalReference:
+      - finos:doc-owasp-llm-top-10
+      - finos:doc-bbc-dpd-chatbot
+      - finos:doc-willison-indirect-prompt-injection
+      - finos:doc-arxiv-jailbreaking-llms
+
+  # FINOS ri-5 cites the same BBC report as ri-10. In the source that link is
+  # duplicated as free text under three different titles; here it is one
+  # Documentation, declared once and referenced twice.
+  - id: finos:ri-5
+    type: Risk
+    name: Foundation Model Versioning
+    url: https://air-governance-framework.finos.org/risks/ri-5_foundation-model-versioning.html
+    hasExternalReference:
+      - finos:doc-bbc-dpd-chatbot
+      - finos:doc-arxiv-prompt-instability
+
+actions:
+  # FINOS mi-3. A mitigation maps to Action, which descends from Control rather
+  # than Entry - hence hasExternalReference is declared on both.
+  - id: finos:mi-3
+    type: Action
+    name: User/App/Model Firewalling/Filtering
+    url: https://air-governance-framework.finos.org/mitigations/mi-3_user-app-model-firewalling-filtering.html
+    hasExternalReference:
+      - finos:doc-llm-guard
+      - finos:doc-deberta-prompt-injection
+      - finos:doc-shieldlm
+
+documents:
+  # --- Tooling (from mi-3 "Additional Resources" -> **Tooling**) -------------
+  - id: finos:doc-llm-guard
+    name: LLM Guard
+    description: >-
+      Open source LLM filter for sanitization, detection of harmful language,
+      prevention of data leakage, and resistance against prompt injection attacks.
+    url: https://github.com/protectai/llm-guard
+    isCategorizedAs:
+      - nexus:extref-category-tooling
+
+  - id: finos:doc-deberta-prompt-injection
+    name: deberta-v3-base-prompt-injection-v2
+    description: >-
+      Fine-tuned deberta-v3-base model developed to detect and classify prompt
+      injection attacks.
+    url: https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2
+    isCategorizedAs:
+      - nexus:extref-category-tooling
+
+  - id: finos:doc-shieldlm
+    name: ShieldLM
+    description: >-
+      Open source bilingual safety detector for identifying safety issues in
+      LLM generations.
+    url: https://github.com/thu-coai/ShieldLM
+    isCategorizedAs:
+      - nexus:extref-category-tooling
+
+  # --- Links (from the "## Links" sections of ri-10 and ri-5) ---------------
+  - id: finos:doc-owasp-llm-top-10
+    name: OWASP Top 10 for LLM Applications (PDF)
+    url: https://owasp.org/www-project-top-10-for-large-language-model-applications/assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_1.pdf
+    isCategorizedAs:
+      - nexus:extref-category-links
+
+  # Cited by ri-10 and ri-5. The source gives this one URL three different
+  # titles; modelling it as one Documentation forces a single canonical name.
+  - id: finos:doc-bbc-dpd-chatbot
+    name: DPD error caused chatbot to swear at customer
+    url: https://www.bbc.co.uk/news/technology-68025677
+    isCategorizedAs:
+      - nexus:extref-category-links
+
+  - id: finos:doc-willison-indirect-prompt-injection
+    name: Indirect Prompt Injection - Simon Willison
+    description: Technical explanation and examples of indirect prompt injection risks.
+    url: https://simonwillison.net/2023/Apr/3/indirect-prompt-injection/
+    isCategorizedAs:
+      - nexus:extref-category-links
+
+  # Carries two labels, exercising the multivalued category.
+  - id: finos:doc-arxiv-jailbreaking-llms
+    name: Jailbreaking LLMs via Prompt Injection - ArXiv
+    description: Research exploring how models can be jailbroken using carefully crafted prompts.
+    url: https://arxiv.org/abs/2302.12173
+    isCategorizedAs:
+      - nexus:extref-category-links
+      - nexus:extref-category-tooling
+
+  - id: finos:doc-arxiv-prompt-instability
+    name: >-
+      Surprisingly Fragile: Assessing and Addressing Prompt Instability in
+      Multimodal Foundation Models
+    url: https://www.arxiv.org/abs/2408.14595
+    isCategorizedAs:
+      - nexus:extref-category-links


### PR DESCRIPTION
## Status

**READY**

## Description

<!-- Commit Message Description
```
Closes: IBM/ai-atlas-nexus#181

Signed-off-by: Noel McLoughlin <noel.mcloughlin@gmail.com>
```
-->

## Impacted Areas in Application

Schema

## Which issue(s) does this pull-request fix?
closes: IBM/ai-atlas-nexus#181

## Any special notes for your reviewer?

Due to #243 I am not sure whether `src/ai_atlas_nexus/ai_risk_ontology/datamodel/ai_risk_ontology.py` should be included in commit (passes local tests) or not.

---

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided
