### PR TITLE
fix: change TypedDict  for python 3.11 / pydantic

### DIFF
--- a/src/ai_atlas_nexus/blocks/inference/params.py
+++ b/src/ai_atlas_nexus/blocks/inference/params.py
@@ -1,8 +1,9 @@
 import dataclasses
-from typing import Any, Dict, List, Literal, Optional, TypeAlias, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, TypeAlias, Union
 
 from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 
 class InferenceEngineCredentials(TypedDict):


### PR DESCRIPTION
## Status

**READY**

## Description
Change TypedDict  to come from typing_extensions for python 3.11 / pydantic support 

This will remove warning/error:
Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
For further information visit https://errors.pydantic.dev/2.13/u/typed-dict-version

Contributes to: Mellea Skills compiler internal list  no.253
Signed-off-by: Inge Vejsbjerg <ingevejs@ie.ibm.com>

## Impacted Areas in Application
Python 3.11 environments

## Any special notes for your reviewer?

---

## Checklist

- [ ] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions.
